### PR TITLE
fix: add missing dependencies pandas and akshare

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ click = ">=8.0"
 beautifulsoup4 = ">=4.9"
 pyyaml = ">=6.0"
 python-dateutil = ">=2.8"
+pandas = ">=2.0"
+akshare = ">=1.10"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"


### PR DESCRIPTION
## 问题

运行时缺少 `pandas` 和 `akshare` 依赖，导致 `ModuleNotFoundError`：

```
ModuleNotFoundError: No module named 'pandas'
ModuleNotFoundError: No module named 'akshare'
```

这两个包在 `adapters/a_stock.py` 中被 import，但未在 `pyproject.toml` 中声明。

## 修复

- 添加 `pandas >= 2.0` 到依赖
- 添加 `akshare >= 1.10` 到依赖

## 验证

安装后 `unified-downloader status`、`search list`、`download single` 均正常运行。