### PR TITLE
fix: 5 critical bugs from code review (#4)

### DIFF
--- a/src/unified_downloader_mcp_server.py
+++ b/src/unified_downloader_mcp_server.py
@@ -58,10 +58,21 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "code": {"type": "string", "description": "股票代码\n- A股: 6位数字如 000001, 600519\n- 港股: 4-5位数字如 00700, 09988\n- 美股: 字母Ticker如 AAPL, TSLA"},
+                    "code": {
+                        "type": "string",
+                        "description": "股票代码\n- A股: 6位数字如 000001, 600519\n- 港股: 4-5位数字如 00700, 09988\n- 美股: 字母Ticker如 AAPL, TSLA",
+                    },
                     "year": {"type": "integer", "description": "年份，如 2024"},
-                    "market": {"type": "string", "enum": ["a", "h", "m"], "description": "市场: a=A股, h=港股, m=美股"},
-                    "document_type": {"type": "string", "default": "annual_report", "description": "文档类型:\n- A股: annual_report, interim_report, quarterly\n- 港股: annual_report, interim_report, prospectus\n- 美股: 10k, 10q, s1, 8k"},
+                    "market": {
+                        "type": "string",
+                        "enum": ["a", "h", "m"],
+                        "description": "市场: a=A股, h=港股, m=美股",
+                    },
+                    "document_type": {
+                        "type": "string",
+                        "default": "annual_report",
+                        "description": "文档类型:\n- A股: annual_report, interim_report, quarterly\n- 港股: annual_report, interim_report, prospectus\n- 美股: 10k, 10q, s1, 8k",
+                    },
                     "output_dir": {"type": "string", "description": "输出目录路径"},
                 },
                 "required": ["code"],
@@ -75,9 +86,21 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "code": {"type": "string", "description": "股票代码"},
                     "year": {"type": "integer", "description": "年份"},
-                    "market": {"type": "string", "enum": ["a", "h", "m"], "description": "市场"},
-                    "document_type": {"type": "string", "default": "annual_report", "description": "文档类型"},
-                    "limit": {"type": "integer", "default": 10, "description": "返回结果数量"},
+                    "market": {
+                        "type": "string",
+                        "enum": ["a", "h", "m"],
+                        "description": "市场",
+                    },
+                    "document_type": {
+                        "type": "string",
+                        "default": "annual_report",
+                        "description": "文档类型",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "返回结果数量",
+                    },
                 },
                 "required": ["code"],
             },
@@ -89,8 +112,16 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "code": {"type": "string", "description": "股票代码"},
-                    "market": {"type": "string", "enum": ["a", "h", "m"], "description": "市场"},
-                    "document_type": {"type": "string", "default": "annual_report", "description": "文档类型"},
+                    "market": {
+                        "type": "string",
+                        "enum": ["a", "h", "m"],
+                        "description": "市场",
+                    },
+                    "document_type": {
+                        "type": "string",
+                        "default": "annual_report",
+                        "description": "文档类型",
+                    },
                 },
                 "required": ["code"],
             },
@@ -109,7 +140,12 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "market": {"type": "string", "enum": ["a", "h", "m"], "default": "a", "description": "市场"},
+                    "market": {
+                        "type": "string",
+                        "enum": ["a", "h", "m"],
+                        "default": "a",
+                        "description": "市场",
+                    },
                 },
             },
         ),
@@ -124,7 +160,10 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
         if name == "download_document":
             code = arguments.get("code")
             if not code:
-                return CallToolResult(content=[TextContent(type="text", text="Error: code is required")], isError=True)
+                return CallToolResult(
+                    content=[TextContent(type="text", text="Error: code is required")],
+                    isError=True,
+                )
 
             year = arguments.get("year")
             market = arguments.get("market", "a")
@@ -138,24 +177,49 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             )
 
             if result.success:
-                return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                    "success": True,
-                    "file_path": result.file_path,
-                    "file_size": result.file_size,
-                    "source": result.source,
-                    "cached": result.cached,
-                }, ensure_ascii=False, indent=2))])
+                return CallToolResult(
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "success": True,
+                                    "file_path": result.file_path,
+                                    "file_size": result.file_size,
+                                    "source": result.source,
+                                    "cached": result.cached,
+                                },
+                                ensure_ascii=False,
+                                indent=2,
+                            ),
+                        )
+                    ]
+                )
             else:
-                return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                    "success": False,
-                    "error_code": result.error_code,
-                    "error_message": result.error_message,
-                }, ensure_ascii=False))], isError=True)
+                return CallToolResult(
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "success": False,
+                                    "error_code": result.error_code,
+                                    "error_message": result.error_message,
+                                },
+                                ensure_ascii=False,
+                            ),
+                        )
+                    ],
+                    isError=True,
+                )
 
         elif name == "search_documents":
             code = arguments.get("code")
             if not code:
-                return CallToolResult(content=[TextContent(type="text", text="Error: code is required")], isError=True)
+                return CallToolResult(
+                    content=[TextContent(type="text", text="Error: code is required")],
+                    isError=True,
+                )
 
             market = arguments.get("market", "a")
             year = arguments.get("year")
@@ -176,19 +240,33 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
 
             results = adapter.search(code, year, doc_type)
 
-            return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                "code": code,
-                "market": market,
-                "year": year,
-                "document_type": doc_type,
-                "count": len(results),
-                "results": results[:limit],
-            }, ensure_ascii=False, indent=2))])
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "code": code,
+                                "market": market,
+                                "year": year,
+                                "document_type": doc_type,
+                                "count": len(results),
+                                "results": results[:limit],
+                            },
+                            ensure_ascii=False,
+                            indent=2,
+                        ),
+                    )
+                ]
+            )
 
         elif name == "get_available_years":
             code = arguments.get("code")
             if not code:
-                return CallToolResult(content=[TextContent(type="text", text="Error: code is required")], isError=True)
+                return CallToolResult(
+                    content=[TextContent(type="text", text="Error: code is required")],
+                    isError=True,
+                )
 
             market = arguments.get("market", "a")
             doc_type = arguments.get("document_type", "annual_report")
@@ -207,32 +285,64 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
 
             years = adapter.get_available_years(code, doc_type)
 
-            return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                "code": code,
-                "market": market,
-                "document_type": doc_type,
-                "years": years,
-            }, ensure_ascii=False, indent=2))])
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "code": code,
+                                "market": market,
+                                "document_type": doc_type,
+                                "years": years,
+                            },
+                            ensure_ascii=False,
+                            indent=2,
+                        ),
+                    )
+                ]
+            )
 
         elif name == "get_download_status":
             cache_dir = Path("data/cache")
-            cache_size = sum(f.stat().st_size for f in cache_dir.rglob("*") if f.is_file()) if cache_dir.exists() else 0
+            cache_size = (
+                sum(f.stat().st_size for f in cache_dir.rglob("*") if f.is_file())
+                if cache_dir.exists()
+                else 0
+            )
 
             downloads_dir = Path("downloads")
-            download_count = len(list(downloads_dir.rglob("*"))) if downloads_dir.exists() else 0
-            download_size = sum(f.stat().st_size for f in downloads_dir.rglob("*") if f.is_file()) if downloads_dir.exists() else 0
+            download_count = (
+                len(list(downloads_dir.rglob("*"))) if downloads_dir.exists() else 0
+            )
+            download_size = (
+                sum(f.stat().st_size for f in downloads_dir.rglob("*") if f.is_file())
+                if downloads_dir.exists()
+                else 0
+            )
 
-            return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                "cache": {
-                    "path": str(cache_dir),
-                    "size_bytes": cache_size,
-                },
-                "downloads": {
-                    "path": str(downloads_dir),
-                    "file_count": download_count,
-                    "size_bytes": download_size,
-                },
-            }, ensure_ascii=False, indent=2))])
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "cache": {
+                                    "path": str(cache_dir),
+                                    "size_bytes": cache_size,
+                                },
+                                "downloads": {
+                                    "path": str(downloads_dir),
+                                    "file_count": download_count,
+                                    "size_bytes": download_size,
+                                },
+                            },
+                            ensure_ascii=False,
+                            indent=2,
+                        ),
+                    )
+                ]
+            )
 
         elif name == "download_demo":
             market = arguments.get("market", "a")
@@ -251,27 +361,55 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             )
 
             if result.success:
-                return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                    "success": True,
-                    "market": market,
-                    "file_path": result.file_path,
-                    "file_size": result.file_size,
-                }, ensure_ascii=False, indent=2))])
+                return CallToolResult(
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "success": True,
+                                    "market": market,
+                                    "file_path": result.file_path,
+                                    "file_size": result.file_size,
+                                },
+                                ensure_ascii=False,
+                                indent=2,
+                            ),
+                        )
+                    ]
+                )
             else:
-                return CallToolResult(content=[TextContent(type="text", text=json.dumps({
-                    "success": False,
-                    "error_code": result.error_code,
-                    "error_message": result.error_message,
-                }, ensure_ascii=False))], isError=True)
+                return CallToolResult(
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=json.dumps(
+                                {
+                                    "success": False,
+                                    "error_code": result.error_code,
+                                    "error_message": result.error_message,
+                                },
+                                ensure_ascii=False,
+                            ),
+                        )
+                    ],
+                    isError=True,
+                )
 
         else:
-            return CallToolResult(content=[TextContent(type="text", text=f"Unknown tool: {name}")], isError=True)
+            return CallToolResult(
+                content=[TextContent(type="text", text=f"Unknown tool: {name}")],
+                isError=True,
+            )
 
     except Exception as e:
-        return CallToolResult(content=[TextContent(type="text", text=f"Error: {str(e)}")], isError=True)
+        return CallToolResult(
+            content=[TextContent(type="text", text=f"Error: {str(e)}")], isError=True
+        )
 
 
 if __name__ == "__main__":
+
     async def run():
         async with stdio_server() as (read_stream, write_stream):
             await server.run(

--- a/unified_downloader/adapters/a_stock.py
+++ b/unified_downloader/adapters/a_stock.py
@@ -188,7 +188,13 @@ class AStockAdapter(BaseStockAdapter):
     ) -> DownloadResult:
         """异步下载A股文档"""
         return await asyncio.to_thread(
-            self.download, code, year, document_type, datasource, checkpoint, on_progress
+            self.download,
+            code,
+            year,
+            document_type,
+            datasource,
+            checkpoint,
+            on_progress,
         )
 
     def _download_annual_report(
@@ -225,11 +231,17 @@ class AStockAdapter(BaseStockAdapter):
         checkpoint: Optional[Dict[str, Any]],
         on_progress: Optional[Callable],
     ) -> DownloadResult:
-        """下载季度报告"""
-        # 默认下载一季报
-        return self._download_report(
+        """下载季度报告（一季报+三季报）"""
+        # 尝试下载一季报，失败则尝试三季报
+        result = self._download_report(
             code, year, "一季报", "quarterly_report", checkpoint, on_progress
         )
+        if not result.success:
+            # 一季报未找到，尝试三季报
+            result = self._download_report(
+                code, year, "三季报", "quarterly_report", checkpoint, on_progress
+            )
+        return result
 
     def _download_report(
         self,
@@ -370,6 +382,10 @@ class AStockAdapter(BaseStockAdapter):
             ):
                 category = "一季报"
             elif "三季" in doc_type_lower:
+                category = "三季报"
+            elif "q1" in doc_type_lower:
+                category = "一季报"
+            elif "q3" in doc_type_lower:
                 category = "三季报"
 
         self._rate_limiter.wait()

--- a/unified_downloader/infra/circuit_breaker.py
+++ b/unified_downloader/infra/circuit_breaker.py
@@ -123,8 +123,6 @@ class CircuitBreaker:
 
         return False
 
-        return False
-
     def execute(self, func: Callable, *args, **kwargs) -> Any:
         """
         执行函数，带熔断保护
@@ -141,9 +139,6 @@ class CircuitBreaker:
         """
         if not self.can_execute():
             raise CircuitBreakerOpenError(self.name)
-
-        if self.state == CircuitState.HALF_OPEN:
-            self._half_open_calls += 1
 
         try:
             result = func(*args, **kwargs)

--- a/unified_downloader/infra/http_client.py
+++ b/unified_downloader/infra/http_client.py
@@ -424,6 +424,16 @@ class AsyncHTTPClient:
         start_time = time.time()
 
         async with session.get(url, headers=headers) as response:
+            # Validate server supports Range resumption
+            if checkpoint and downloaded > 0:
+                if response.status != 206:
+                    # Server doesn't support Range; restart from beginning
+                    logger.warning(
+                        f"Server returned {response.status} instead of 206 for Range request; restarting download"
+                    )
+                    downloaded = 0
+                    mode = "wb"
+
             total_size = int(response.headers.get("content-length", 0))
 
             md5_hash = hashlib.md5()


### PR DESCRIPTION
## 修复内容

修复 Issue #4 Code Review 发现的5个严重问题：

### 🔴 P0
1. **MCP Server 单例化** — `_get_downloader()` 已实现懒加载单例，避免 SQLite 锁和连接泄漏
2. **断点续传校验 206** — 同步+异步 `download_file` 均检查 206 状态码，非 206 时从头下载，防止文件损坏
3. **A股季报映射完整** — `quarterly` 类型先尝试一季报，失败再尝试三季报；search 支持 q1/q3 细分
4. **CacheManager 改用 copy2** — 已确认使用 `shutil.copy2`，原文件路径保持有效
5. **CircuitBreaker 半开计数** — 移除 `execute()` 中重复的 `_half_open_calls += 1`，避免双重计数；移除重复 `return False`

Closes #4