### PR TITLE
fix: normalize form type in search to match SEC filing format

### DIFF
--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -796,12 +796,32 @@ class MStockAdapter(BaseStockAdapter):
             )
         )
 
+    # CLI 文档类型 → SEC form type 映射
+    _FORM_TYPE_MAP = {
+        "10k": "10-K",
+        "10q": "10-Q",
+        "6k": "6-K",
+        "8k": "8-K",
+        "20f": "20-F",
+        "s1": "S-1",
+        "s1a": "S-1/A",
+    }
+
+    @classmethod
+    def _normalize_form_type(cls, form_type: str) -> str:
+        """将 CLI 文档类型(如 10k)标准化为 SEC form type(如 10-K)"""
+        normalized = cls._FORM_TYPE_MAP.get(form_type.lower())
+        if normalized:
+            return normalized
+        # 已经是标准格式(如 10-K)或未知类型，原样返回
+        return form_type
+
     def search(
         self, code: str, year: Optional[int] = None, document_type: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """搜索可用文档"""
         ticker = code.upper()
-        form_type = document_type or "10-K"
+        form_type = self._normalize_form_type(document_type or "10-K")
 
         try:
             return self._search_filings(ticker, form_type, year, size=20)


### PR DESCRIPTION
## Problem

CLI 搜索美股文档时传 // 等格式，但 edgar API 需要 // 等 SEC 标准格式，导致搜索始终返回 0 条结果。

搜索 NVDA 所有年份 10k...

找到 20 个文档:

1. 10-K - 2026-02-25
   Accession: 0001045810-26-000021
2. 10-K - 2025-02-26
   Accession: 0001045810-25-000023
3. 10-K - 2024-02-21
   Accession: 0001045810-24-000029
4. 10-K - 2023-02-24
   Accession: 0001045810-23-000017
5. 10-K - 2022-03-18
   Accession: 0001045810-22-000036
6. 10-K - 2021-02-26
   Accession: 0001045810-21-000010
7. 10-K - 2020-02-20
   Accession: 0001045810-20-000010
8. 10-K - 2019-02-21
   Accession: 0001045810-19-000023
9. 10-K - 2018-02-28
   Accession: 0001045810-18-000010
10. 10-K - 2017-03-01
   Accession: 0001045810-17-000027

... 还有 10 个文档
搜索 NVDA 所有年份 10k...

找到 20 个文档:

1. 10-K - 2026-02-25
   Accession: 0001045810-26-000021
2. 10-K - 2025-02-26
   Accession: 0001045810-25-000023
3. 10-K - 2024-02-21
   Accession: 0001045810-24-000029
4. 10-K - 2023-02-24
   Accession: 0001045810-23-000017
5. 10-K - 2022-03-18
   Accession: 0001045810-22-000036
6. 10-K - 2021-02-26
   Accession: 0001045810-21-000010
7. 10-K - 2020-02-20
   Accession: 0001045810-20-000010
8. 10-K - 2019-02-21
   Accession: 0001045810-19-000023
9. 10-K - 2018-02-28
   Accession: 0001045810-18-000010
10. 10-K - 2017-03-01
   Accession: 0001045810-17-000027

... 还有 10 个文档

## Root Cause

 将 CLI 传入的 （如 ）直接透传给  → ，而 edgar 的  不识别小写无连字符格式，只认 。

下载路径没有这个问题，因为  等方法内部已经硬编码了 。

## Fix

新增  映射表和  类方法，在  入口处将 CLI 格式标准化为 SEC 格式：

| CLI 输入 | 标准化输出 |
|---------|----------|
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |
|  |  |

## Verification

所有文档类型搜索已验证通过：
- ✅  → 20 results (NVDA)
- ✅  → 20 results (NVDA)
- ✅  → 20 results (NVDA)
- ✅  → 8 results (NVDA)
- ✅ / → 0 results (正确，NVDA 是美国本土公司无需 6-K/20-F)