### PR TITLE
fix: restore semantic filenames for US cache hits

### DIFF
--- a/tests/test_us_cache_semantic_filename.py
+++ b/tests/test_us_cache_semantic_filename.py
@@ -17,6 +17,12 @@ def test_us_cache_hit_restores_semantic_download_filename(tmp_path, monkeypatch)
     monkeypatch.chdir(tmp_path)
     downloader = UnifiedDownloader()
 
+    monkeypatch.setattr(
+        downloader._adapters[Market.M],
+        "_get_annual_form_type",
+        lambda code: "10-K",
+    )
+
     source = tmp_path / "AAPL_2024_10K.pdf"
     source.write_bytes(b"%PDF-1.4\nsemantic cache fixture\n" + b"x" * 128)
     downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
@@ -36,6 +42,12 @@ def test_us_cache_hit_with_pdf_request_ignores_cached_html(tmp_path, monkeypatch
     """--pdf should not return a cached HTML file for US filings."""
     monkeypatch.chdir(tmp_path)
     downloader = UnifiedDownloader()
+
+    monkeypatch.setattr(
+        downloader._adapters[Market.M],
+        "_get_annual_form_type",
+        lambda code: "10-K",
+    )
 
     source = tmp_path / "AAPL_2024_10K.html"
     source.write_text("<html><body>cached html</body></html>", encoding="utf-8")
@@ -60,3 +72,47 @@ def test_us_cache_hit_with_pdf_request_ignores_cached_html(tmp_path, monkeypatch
     assert result.success is True
     assert result.file_path == "downloads/m/AAP/AAPL_2024_10K.pdf"
     assert Path(result.file_path).suffix.lower() == ".pdf"
+
+
+def test_us_annual_report_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
+    """US annual_report cache hits must preserve FPI 20-F semantic names."""
+    monkeypatch.chdir(tmp_path)
+    downloader = UnifiedDownloader()
+    monkeypatch.setattr(
+        downloader._adapters[Market.M],
+        "_get_annual_form_type",
+        lambda code: "20-F",
+    )
+
+    source = tmp_path / "PDD_2024_20F.pdf"
+    source.write_bytes(b"%PDF-1.4\nfpi annual cache fixture\n" + b"x" * 128)
+    downloader._cache_manager.put("m", "PDD", 2024, "annual_report", source)
+    source.unlink()
+
+    result = downloader.download("PDD", 2024, "annual_report", market=Market.M)
+
+    assert result.success is True
+    assert result.cached is True
+    assert result.file_path == str(Path("downloads/m/PDD/PDD_2024_20F.pdf"))
+
+
+def test_us_quarterly_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
+    """US quarterly/10q cache hits must preserve FPI 6-K semantic names."""
+    monkeypatch.chdir(tmp_path)
+    downloader = UnifiedDownloader()
+    monkeypatch.setattr(
+        downloader._adapters[Market.M],
+        "_get_quarterly_form_type",
+        lambda code: "6-K",
+    )
+
+    source = tmp_path / "PDD_2024_6K.pdf"
+    source.write_bytes(b"%PDF-1.4\nfpi quarterly cache fixture\n" + b"x" * 128)
+    downloader._cache_manager.put("m", "PDD", 2024, "10q", source)
+    source.unlink()
+
+    result = downloader.download("PDD", 2024, "10q", market=Market.M)
+
+    assert result.success is True
+    assert result.cached is True
+    assert result.file_path == str(Path("downloads/m/PDD/PDD_2024_6K.pdf"))

--- a/tests/test_us_cache_semantic_filename.py
+++ b/tests/test_us_cache_semantic_filename.py
@@ -1,0 +1,62 @@
+"""Regression tests for semantic filenames on US cache hits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from unified_downloader.core.downloader import UnifiedDownloader
+from unified_downloader.models.enums import Market
+
+
+def test_us_cache_hit_restores_semantic_download_filename(tmp_path, monkeypatch):
+    """A cached US filing must not be returned as data/cache/.../<md5>.pdf.
+
+    IMA uses basename(file_path) as searchable file name. Returning cache hash paths
+    makes uploaded US annual/quarterly filings impossible to identify.
+    """
+    monkeypatch.chdir(tmp_path)
+    downloader = UnifiedDownloader()
+
+    source = tmp_path / "AAPL_2024_10K.pdf"
+    source.write_bytes(b"%PDF-1.4\nsemantic cache fixture\n" + b"x" * 128)
+    downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+    source.unlink()
+
+    result = downloader.download("AAPL", 2024, "10k", market=Market.M)
+
+    assert result.success is True
+    assert result.cached is True
+    assert result.file_path == str(Path("downloads/m/AAP/AAPL_2024_10K.pdf"))
+    assert Path(result.file_path).exists()
+    assert Path(result.file_path).read_bytes().startswith(b"%PDF-1.4")
+    assert not Path(result.file_path).name.startswith("9")  # not a hash-like cache key
+
+
+def test_us_cache_hit_with_pdf_request_ignores_cached_html(tmp_path, monkeypatch):
+    """--pdf should not return a cached HTML file for US filings."""
+    monkeypatch.chdir(tmp_path)
+    downloader = UnifiedDownloader()
+
+    source = tmp_path / "AAPL_2024_10K.html"
+    source.write_text("<html><body>cached html</body></html>", encoding="utf-8")
+    downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+    source.unlink()
+
+    calls = []
+
+    def fake_download(**kwargs):
+        calls.append(kwargs)
+        out = Path("downloads/m/AAP/AAPL_2024_10K.pdf")
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"%PDF-1.4 generated\n" + b"x" * 128)
+        from unified_downloader.models.entities import DownloadResult
+        return DownloadResult(success=True, file_path=str(out), file_size=out.stat().st_size)
+
+    monkeypatch.setattr(downloader._adapters[Market.M], "download", fake_download)
+
+    result = downloader.download("AAPL", 2024, "10k", market=Market.M, convert_to_pdf=True)
+
+    assert calls, "cached HTML must not short-circuit a US --pdf download"
+    assert result.success is True
+    assert result.file_path == "downloads/m/AAP/AAPL_2024_10K.pdf"
+    assert Path(result.file_path).suffix.lower() == ".pdf"

--- a/unified_downloader/core/async_downloader.py
+++ b/unified_downloader/core/async_downloader.py
@@ -61,7 +61,15 @@ class AsyncUnifiedDownloader:
             market.value, code, year, document_type
         )
         if cached_path:
-            return DownloadResult(success=True, file_path=cached_path, cached=True)
+            restored_path = self._downloader._restore_semantic_cache_path(
+                market, code, year, document_type, cached_path
+            )
+            return DownloadResult(
+                success=True,
+                file_path=restored_path,
+                cached=True,
+                metadata={"cache_path": cached_path},
+            )
 
         # 执行下载
         return await self._download_direct(

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -369,6 +369,30 @@ class UnifiedDownloader:
 
         ticker = code.upper()
         doc_label = self._semantic_us_doc_label(document_type)
+        if market == Market.M:
+            adapter = self._adapters.get(Market.M)
+            normalized = document_type.lower().replace("-", "_")
+            try:
+                if normalized in ("annual_report", "10k", "ten_k") and hasattr(
+                    adapter, "_get_annual_form_type"
+                ):
+                    doc_label = self._semantic_us_doc_label(
+                        adapter._get_annual_form_type(ticker)  # type: ignore[attr-defined]
+                    )
+                elif normalized in ("quarterly", "10q", "ten_q") and hasattr(
+                    adapter, "_get_quarterly_form_type"
+                ):
+                    doc_label = self._semantic_us_doc_label(
+                        adapter._get_quarterly_form_type(ticker)  # type: ignore[attr-defined]
+                    )
+            except Exception as exc:
+                logger.debug(
+                    "Failed to resolve US semantic form type for %s %s: %s",
+                    ticker,
+                    document_type,
+                    exc,
+                )
+
         base_dir = Path("downloads") / market.value / ticker[:3]
         if year is None:
             filename = f"{ticker}_{doc_label}{cached.suffix}"

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -2,7 +2,9 @@
 
 import logging
 import re
+import shutil
 import time
+from pathlib import Path
 from typing import Optional, List, Dict, Any, Callable
 import concurrent.futures
 
@@ -153,22 +155,39 @@ class UnifiedDownloader:
                 market.value, code, year, document_type
             )
             if cached_path:
-                duration_ms = int((time.time() - start_time) * 1000)
-                self._log_event(
-                    EventType.CACHE_HIT,
-                    market,
-                    code,
-                    year,
-                    document_type,
-                    True,
-                    duration_ms=duration_ms,
+                # US SEC downloads are cached under MD5 keys.  Returning those
+                # paths directly makes downstream IMA uploads show hash filenames.
+                # Restore a semantic downloads/... filename before reporting a hit.
+                restored_path = self._restore_semantic_cache_path(
+                    market, code, year, document_type, cached_path
                 )
-                return DownloadResult(
-                    success=True,
-                    file_path=cached_path,
-                    cached=True,
-                    duration_ms=duration_ms,
-                )
+
+                # If the caller explicitly asks for PDF but the cached US artifact
+                # is HTML, do not short-circuit here.  Let the US adapter download
+                # / convert so IMA receives an uploadable PDF.
+                if not (
+                    market == Market.M
+                    and convert_to_pdf is True
+                    and Path(restored_path).suffix.lower() in (".html", ".htm")
+                ):
+                    duration_ms = int((time.time() - start_time) * 1000)
+                    self._log_event(
+                        EventType.CACHE_HIT,
+                        market,
+                        code,
+                        year,
+                        document_type,
+                        True,
+                        duration_ms=duration_ms,
+                    )
+                    return DownloadResult(
+                        success=True,
+                        file_path=restored_path,
+                        file_size=Path(restored_path).stat().st_size,
+                        cached=True,
+                        duration_ms=duration_ms,
+                        metadata={"cache_path": cached_path},
+                    )
 
         # 生成任务ID
         task_id = self._generate_task_id(market, code, year, document_type)
@@ -326,6 +345,65 @@ class UnifiedDownloader:
                 error_message=str(e),
                 duration_ms=duration_ms,
             )
+
+
+    def _restore_semantic_cache_path(
+        self,
+        market: Market,
+        code: str,
+        year: Optional[int],
+        document_type: str,
+        cached_path: str,
+    ) -> str:
+        """Return a human-readable downloads path for a cached artifact.
+
+        CacheManager stores artifacts as ``data/cache/<market>/<prefix>/<md5>.*``.
+        That is fine internally, but callers pass ``DownloadResult.file_path`` to
+        IMA, whose displayed/searchable document name is the source basename.
+        For US annual/quarterly SEC filings especially, returning a hash filename
+        makes uploaded documents unsearchable.
+        """
+        cached = Path(cached_path)
+        if market != Market.M or not cached.exists():
+            return cached_path
+
+        ticker = code.upper()
+        doc_label = self._semantic_us_doc_label(document_type)
+        base_dir = Path("downloads") / market.value / ticker[:3]
+        if year is None:
+            filename = f"{ticker}_{doc_label}{cached.suffix}"
+        else:
+            filename = f"{ticker}_{year}_{doc_label}{cached.suffix}"
+        target = base_dir / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        if cached.resolve() != target.resolve():
+            shutil.copy2(str(cached), str(target))
+        return str(target)
+
+    @staticmethod
+    def _semantic_us_doc_label(document_type: str) -> str:
+        """Normalize US document type aliases to readable SEC form labels."""
+        normalized = document_type.lower().replace("-", "_")
+        labels = {
+            "annual_report": "10K",
+            "10k": "10K",
+            "ten_k": "10K",
+            "quarterly": "10Q",
+            "10q": "10Q",
+            "ten_q": "10Q",
+            "20f": "20F",
+            "20_f": "20F",
+            "twenty_f": "20F",
+            "6k": "6K",
+            "6_k": "6K",
+            "8k": "8K",
+            "8_k": "8K",
+            "s1": "S1",
+            "s1a": "S1A",
+            "prospectus": "S1",
+        }
+        return labels.get(normalized, document_type.replace("-", "").upper())
 
     def batch_download(
         self,


### PR DESCRIPTION
## Summary
- restore US cache-hit artifacts from data/cache MD5 names to semantic downloads/m/<prefix>/<TICKER>_<YEAR>_<FORM>.<ext> paths before returning DownloadResult.file_path
- avoid short-circuiting US --pdf requests when cache contains HTML, so downstream IMA uploads still get PDFs
- apply the same semantic cache path restoration to async downloader cache hits
- add regression tests covering hash cache paths and US --pdf HTML-cache bypass

## Verification
- python3 -m py_compile unified_downloader/core/downloader.py unified_downloader/core/async_downloader.py
- python3 -m pytest -q
- CLI cache-hit double check: python3 -m unified_downloader.cli download single APP -y 2026 -t 10k -m m returns downloads/m/APP/APP_2026_10K.pdf, not data/cache/.../<hash>.pdf

## Notes
- Existing runtime/untracked files (DAILY_LOG.md, config/, data/, scripts/) were not included in this PR.
- Local historical US state hash entries were restored to semantic local file paths; IMA re-upload is currently blocked by API rate limit: 请求超量，请明日再试.