### PR TITLE
fix: persist quarterly form type in bulk state

### DIFF
--- a/scripts/bulk_download.py
+++ b/scripts/bulk_download.py
@@ -223,7 +223,6 @@ def set_doc_status(state: dict, category: str, year: str, quarter: str,
         if fsize: entry["size"] = fsize
         if reason: entry["reason"] = reason
         if form_type: entry["form_type"] = form_type
-        if form_type: entry["form_type"] = form_type
         if status == "uploaded":
             entry["ima"] = "uploaded"
         elif status == "download_failed" or status == "ima_failed":
@@ -238,8 +237,11 @@ def set_doc_status(state: dict, category: str, year: str, quarter: str,
         if filepath: entry["file"] = str(filepath)
         if fsize: entry["size"] = fsize
         if reason: entry["reason"] = reason
+        if form_type: entry["form_type"] = form_type
         if status == "uploaded":
             entry["ima"] = "uploaded"
+        elif status == "download_failed" or status == "ima_failed":
+            entry["ima"] = "failed"
 
 
 def _quarterly_entry(state, year, qlabel):

--- a/tests/test_bulk_download_us_quarterly.py
+++ b/tests/test_bulk_download_us_quarterly.py
@@ -104,3 +104,25 @@ def test_quarterly_skipped_can_be_retried_by_fallback_form():
 
     assert bulk.should_skip_quarterly_candidate(state, "2025", "Q1-Q3") is False
     assert bulk.should_mark_quarterly_unavailable(state, "2025", "Q1-Q3", "6k") is True
+
+
+def test_set_doc_status_persists_quarterly_form_type_for_fallback_protection():
+    bulk = load_bulk_module()
+    state = {"code": "AAPL", "annual": {}, "quarterly": {}}
+
+    bulk.set_doc_status(
+        state,
+        "quarterly",
+        "2025",
+        "Q1-Q3",
+        "ima_failed",
+        filepath="downloads/m/AAP/AAPL_2025_10Q.pdf",
+        fsize=1234567,
+        form_type="10q",
+    )
+
+    entry = state["quarterly"]["2025"]["Q1-Q3"]
+    assert entry["form_type"] == "10q"
+    assert entry["ima"] == "failed"
+    assert bulk.should_mark_quarterly_unavailable(state, "2025", "Q1-Q3", "6k") is False
+    assert bulk.should_mark_quarterly_unavailable(state, "2025", "Q1-Q3", "10q") is True


### PR DESCRIPTION
## Summary
- persist `form_type` on quarterly bulk entries, not just annual entries
- remove duplicate annual `form_type` assignment
- persist `ima=failed` for quarterly `ima_failed` / `download_failed` entries so summaries count failures
- add end-to-end regression test using real `set_doc_status(..., form_type="10q")` then verifying fallback protection against 6-K unavailable overwrite

## Verification
- `python3 -m py_compile scripts/bulk_download.py tests/test_bulk_download_us_quarterly.py`
- `python3 -m pytest tests/test_bulk_download_us_quarterly.py -q`
- manual reproduction now returns `form_type=10q`, `ima=failed`, and `should_mark_quarterly_unavailable(..., "6k") == False`

Fixes critical item in #22.
