### PR TITLE
fix: avoid repeated US cache restore copies

### DIFF
--- a/tests/test_us_cache_semantic_filename.py
+++ b/tests/test_us_cache_semantic_filename.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from unified_downloader.core.downloader import UnifiedDownloader
 from unified_downloader.models.enums import Market
 
@@ -116,3 +118,80 @@ def test_us_quarterly_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
     assert result.success is True
     assert result.cached is True
     assert result.file_path == str(Path("downloads/m/PDD/PDD_2024_6K.pdf"))
+
+
+def test_us_cache_hit_exposes_original_cache_path_metadata(tmp_path, monkeypatch):
+    """Cache-hit callers can inspect the original hash cache path when needed."""
+    monkeypatch.chdir(tmp_path)
+    downloader = UnifiedDownloader()
+    monkeypatch.setattr(
+        downloader._adapters[Market.M],
+        "_get_annual_form_type",
+        lambda code: "10-K",
+    )
+
+    source = tmp_path / "AAPL_2024_10K.pdf"
+    source.write_bytes(b"%PDF-1.4\nmetadata fixture\n" + b"x" * 128)
+    downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+    source.unlink()
+
+    result = downloader.download("AAPL", 2024, "10k", market=Market.M)
+
+    assert result.metadata["cache_path"].startswith("data/cache/m/AAP/")
+    assert Path(result.metadata["cache_path"]).exists()
+
+
+def test_us_cache_hit_does_not_recopied_existing_semantic_file(tmp_path, monkeypatch):
+    """Repeated cache hits should not rewrite an unchanged semantic target."""
+    monkeypatch.chdir(tmp_path)
+    downloader = UnifiedDownloader()
+    monkeypatch.setattr(
+        downloader._adapters[Market.M],
+        "_get_annual_form_type",
+        lambda code: "10-K",
+    )
+
+    source = tmp_path / "AAPL_2024_10K.pdf"
+    source.write_bytes(b"%PDF-1.4\ncopy fixture\n" + b"x" * 128)
+    downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+    source.unlink()
+
+    first = downloader.download("AAPL", 2024, "10k", market=Market.M)
+    target = Path(first.file_path)
+    first_mtime = target.stat().st_mtime_ns
+
+    def fail_copy(*args, **kwargs):  # pragma: no cover - called only on regression
+        raise AssertionError("copy2 should not run when semantic target is already current")
+
+    monkeypatch.setattr("unified_downloader.core.downloader.shutil.copy2", fail_copy)
+    second = downloader.download("AAPL", 2024, "10k", market=Market.M)
+
+    assert second.file_path == first.file_path
+    assert target.stat().st_mtime_ns == first_mtime
+
+
+@pytest.mark.asyncio
+async def test_async_us_cache_hit_restores_semantic_filename(tmp_path, monkeypatch):
+    """Async downloader cache hits should match sync semantic filename behavior."""
+    monkeypatch.chdir(tmp_path)
+    from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+
+    downloader = AsyncUnifiedDownloader()
+    monkeypatch.setattr(
+        downloader._downloader._adapters[Market.M],
+        "_get_annual_form_type",
+        lambda code: "10-K",
+    )
+
+    source = tmp_path / "AAPL_2024_10K.pdf"
+    source.write_bytes(b"%PDF-1.4\nasync cache fixture\n" + b"x" * 128)
+    downloader._downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+    source.unlink()
+
+    result = await downloader.download("AAPL", 2024, "10k", market=Market.M)
+
+    assert result.success is True
+    assert result.cached is True
+    assert result.file_path == str(Path("downloads/m/AAP/AAPL_2024_10K.pdf"))
+    assert result.metadata["cache_path"].startswith("data/cache/m/AAP/")
+    await downloader.close()

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -369,29 +369,28 @@ class UnifiedDownloader:
 
         ticker = code.upper()
         doc_label = self._semantic_us_doc_label(document_type)
-        if market == Market.M:
-            adapter = self._adapters.get(Market.M)
-            normalized = document_type.lower().replace("-", "_")
-            try:
-                if normalized in ("annual_report", "10k", "ten_k") and hasattr(
-                    adapter, "_get_annual_form_type"
-                ):
-                    doc_label = self._semantic_us_doc_label(
-                        adapter._get_annual_form_type(ticker)  # type: ignore[attr-defined]
-                    )
-                elif normalized in ("quarterly", "10q", "ten_q") and hasattr(
-                    adapter, "_get_quarterly_form_type"
-                ):
-                    doc_label = self._semantic_us_doc_label(
-                        adapter._get_quarterly_form_type(ticker)  # type: ignore[attr-defined]
-                    )
-            except Exception as exc:
-                logger.debug(
-                    "Failed to resolve US semantic form type for %s %s: %s",
-                    ticker,
-                    document_type,
-                    exc,
+        adapter = self._adapters.get(Market.M)
+        normalized = document_type.lower().replace("-", "_")
+        try:
+            if normalized in ("annual_report", "10k", "ten_k") and hasattr(
+                adapter, "_get_annual_form_type"
+            ):
+                doc_label = self._semantic_us_doc_label(
+                    adapter._get_annual_form_type(ticker)  # type: ignore[attr-defined]
                 )
+            elif normalized in ("quarterly", "10q", "ten_q") and hasattr(
+                adapter, "_get_quarterly_form_type"
+            ):
+                doc_label = self._semantic_us_doc_label(
+                    adapter._get_quarterly_form_type(ticker)  # type: ignore[attr-defined]
+                )
+        except Exception as exc:
+            logger.debug(
+                "Failed to resolve US semantic form type for %s %s: %s",
+                ticker,
+                document_type,
+                exc,
+            )
 
         base_dir = Path("downloads") / market.value / ticker[:3]
         if year is None:
@@ -401,7 +400,9 @@ class UnifiedDownloader:
         target = base_dir / filename
         target.parent.mkdir(parents=True, exist_ok=True)
 
-        if cached.resolve() != target.resolve():
+        if cached.resolve() != target.resolve() and (
+            not target.exists() or target.stat().st_size != cached.stat().st_size
+        ):
             shutil.copy2(str(cached), str(target))
         return str(target)
 


### PR DESCRIPTION
## Summary
- flatten the redundant `if market == Market.M` block in `_restore_semantic_cache_path`
- avoid re-copying an unchanged semantic cache target on every US cache hit
- add sync metadata regression test for `metadata["cache_path"]`
- add regression test proving repeated cache hits do not call `shutil.copy2` when the semantic target is current
- add async cache-hit regression coverage for semantic filename + metadata behavior

## Verification
- `python3 -m py_compile unified_downloader/core/downloader.py unified_downloader/core/async_downloader.py tests/test_us_cache_semantic_filename.py`
- `python3 -m pytest tests/test_us_cache_semantic_filename.py tests/test_bulk_download_us_quarterly.py -q` → 14 passed

## Notes
- Addresses issue #21 items 1, 2, and 3.
- Item 4 (private `_get_annual_form_type` / `_get_quarterly_form_type` coupling) is intentionally left for a separate architecture PR to avoid expanding this cleanup diff into adapter API changes.
