### PR TITLE
chore: clean up bulk download retry path

### DIFF
--- a/scripts/bulk_download.py
+++ b/scripts/bulk_download.py
@@ -3,7 +3,7 @@
 批量下载单只股票的年报/季报 → IMA 知识库（细粒度状态追踪版）。
 
 用法:
-    cd /root/code/unified-downloader && python3 scripts/bulk_download.py \\
+    cd <repo-root> && python3 scripts/bulk_download.py \\
         --code 600519 --market a --name 贵州茅台
 
 输出文件:
@@ -38,13 +38,14 @@ def setup_logging(code: str):
     logger.addHandler(ch)
     return logger
 
-log = None  # 延迟初始化
+log = logging.getLogger("bulk")
 
 # ── 路径常量 ──
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
 ADR_MAP_FILE = PROJECT_ROOT / "config" / "adr_map.json"
-IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
+DEFAULT_IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
+IMA_SYNC_SCRIPT = Path(os.environ.get("IMA_SYNC_SCRIPT_PATH", DEFAULT_IMA_SYNC_SCRIPT))
 TZ_CN = timezone(timedelta(hours=8))
 
 ANNUAL_MAP = {"CN": "annual_report", "HK": "annual_report", "US": "10k", "US_20F": "20f"}
@@ -119,9 +120,9 @@ def download_one(code, market, year, rtype, retries=3):
         cmd = ["python3", "-m", "unified_downloader.cli", "download", "single",
                code, "-y", year, "-t", rtype, "-m", flag]
         # 美股 SEC 原始文件通常是 HTML；IMA 文件上传不接受本地 HTML。
-        # 同时 unified-downloader 的 --pdf 对 cache hit 不会二次转换，因此 US 必须禁用缓存。
+        # PR #19 fixed cache-hit + --pdf so cache can be reused safely here.
         if market == "US":
-            cmd.extend(["--pdf", "--no-cache"])
+            cmd.append("--pdf")
         rc, out, err = run(cmd, timeout=180 if market == "US" else 120)
         if rc != 0:
             log.warning("  download command failed rc=%s cmd=%s stdout=%s stderr=%s",

--- a/scripts/bulk_scheduler.py
+++ b/scripts/bulk_scheduler.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+批量下载调度器（细粒度状态版）
+- 每小时 cron 触发
+- 从队列取下一只处理
+- 显示详细的 per-年/per-季度 状态
+"""
+
+from __future__ import annotations
+
+import json, subprocess, sys
+from subprocess import TimeoutExpired
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+QUEUE_FILE = PROJECT_ROOT / "data" / "bulk_download_queue.json"
+STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
+LOG_FILE = PROJECT_ROOT / "logs" / "bulk_download.log"
+FAIL_LOG = PROJECT_ROOT / "logs" / "failures.log"
+SCRIPT = PROJECT_ROOT / "scripts" / "bulk_download.py"
+TZ_CN = timezone(timedelta(hours=8))
+
+STATUS_ICONS = {
+    "uploaded":  "✅", "downloaded": "📥", "skipped": "⬜",
+    "download_failed": "❌", "ima_failed": "⚠️", "pending": "⬜",
+}
+
+DEDUP_US = {"TCEHY.US", "BEKE.US", "HTHT.US"}
+
+
+def init_queue():
+    sys.path.insert(0, str(Path.home() / "code" / "morning-brief"))
+    from src.utils.database import get_connection
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT stock_code,stock_name,market FROM watchlist WHERE is_active=1 AND is_index=0 ORDER BY market,stock_code")
+    rows = cur.fetchall()
+    conn.close()
+
+    queue = []
+    for code, name, market in rows:
+        if market == "US" and code in DEDUP_US:
+            continue
+        queue.append({"code":code,"name":name,"market":market,"status":"pending",
+                       "annual_ok":0,"quarterly_ok":0,"failures":0})
+    QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    QUEUE_FILE.write_text(json.dumps({
+        "created_at": datetime.now(TZ_CN).isoformat(),
+        "total":len(queue),"pending":len(queue),"done":0,"failed":0,
+        "stocks":queue
+    }, ensure_ascii=False, indent=2))
+    print(f"Queue: {len(queue)} stocks (CN:{sum(1 for s in queue if s['market']=='CN')} "
+          f"HK:{sum(1 for s in queue if s['market']=='HK')} "
+          f"US:{sum(1 for s in queue if s['market']=='US')})")
+
+
+def _find_state(code: str) -> Path | None:
+    """查找状态文件（支持带/不带后缀的代码）"""
+    sf = STATE_DIR / f"{code}.json"
+    if sf.exists():
+        return sf
+    # Try stripping suffix
+    clean = code.replace(".US","").replace(".SH","").replace(".SZ","").replace(".HK","")
+    sf2 = STATE_DIR / f"{clean}.json"
+    return sf2 if sf2.exists() else None
+
+
+
+def compute_summary_from_state(st: dict) -> dict:
+    """Compute summary from per-document state when summary is missing/stale."""
+    sm = {
+        "annual_ok": 0, "annual_skipped": 0, "annual_failed": 0,
+        "quarterly_ok": 0, "quarterly_skipped": 0, "quarterly_failed": 0,
+        "ima_ok": 0, "ima_failed": 0,
+    }
+    for d in st.get("annual", {}).values():
+        status = d.get("status", "")
+        if status in ("downloaded", "uploaded"):
+            sm["annual_ok"] += 1
+        elif status == "skipped":
+            sm["annual_skipped"] += 1
+        elif "failed" in status:
+            sm["annual_failed"] += 1
+        if d.get("ima") == "uploaded":
+            sm["ima_ok"] += 1
+        elif d.get("ima") == "failed":
+            sm["ima_failed"] += 1
+    for qs in st.get("quarterly", {}).values():
+        for d in qs.values():
+            status = d.get("status", "")
+            if status in ("downloaded", "uploaded"):
+                sm["quarterly_ok"] += 1
+            elif status == "skipped":
+                sm["quarterly_skipped"] += 1
+            elif "failed" in status:
+                sm["quarterly_failed"] += 1
+            if d.get("ima") == "uploaded":
+                sm["ima_ok"] += 1
+            elif d.get("ima") == "failed":
+                sm["ima_failed"] += 1
+    return sm
+
+
+def get_state_summary(st: dict) -> dict:
+    """Return a reliable summary even for older state files without summary."""
+    sm = st.get("summary") or {}
+    computed = compute_summary_from_state(st)
+    if not sm or all(sm.get(k, 0) == 0 for k in ("annual_ok", "quarterly_ok", "ima_ok")):
+        return computed
+    return {**computed, **sm}
+
+
+def summarize_years(entries: dict, status_values: set) -> list[str]:
+    return sorted(
+        [y for y, d in entries.items() if d.get("status") in status_values],
+        reverse=True,
+    )
+
+
+def format_years(years: list[str]) -> str:
+    return ", ".join(years) if years else "无"
+
+
+def build_stock_summary(code: str, stock: dict, st: dict | None, timed_out: bool = False) -> str:
+    """Human-readable precise summary for cron/user notification."""
+    name = stock.get("name", "")
+    if not st:
+        return f"{code} {name}: 无状态文件"
+    sm = get_state_summary(st)
+    annual = st.get("annual", {})
+    uploaded = summarize_years(annual, {"uploaded", "downloaded"})
+    skipped = summarize_years(annual, {"skipped"})
+    failed = sorted(
+        [y for y, d in annual.items() if "failed" in d.get("status", "")],
+        reverse=True,
+    )
+    parts = [
+        f"{code} {name}: 年报成功 {len(uploaded)} ({format_years(uploaded)})",
+    ]
+    if skipped:
+        parts.append(f"未找到/跳过 {len(skipped)} ({format_years(skipped)})")
+    if failed:
+        parts.append(f"失败 {len(failed)} ({format_years(failed)})")
+    if timed_out or st.get("interrupted"):
+        intr = st.get("interrupted", {})
+        at = intr.get("at", "未知位置")
+        parts.append(f"超时/中断于 {at}，下次需从未完成年份继续或重试")
+    parts.append(f"IMA {sm.get('ima_ok', 0)}")
+    return "；".join(parts)
+
+def show_status():
+    if not QUEUE_FILE.exists():
+        print("No queue. Run --init first.")
+        return
+
+    q = json.loads(QUEUE_FILE.read_text())
+    print(f"\n{'='*70}")
+    print(f"  批量下载状态 — {q['total']} stocks  "
+          f"✅{q['done']}  ❌{q['failed']}  ⬜{q['pending']}")
+    print(f"{'='*70}\n")
+
+    for s in q["stocks"]:
+        marker = {"pending":"⬜","processing":"🔄","done":"✅","failed":"❌"}.get(s["status"],"?")
+        code = s["code"]
+
+        # 读取细粒度状态
+        sf = _find_state(code)
+        detail = ""
+        if sf:
+            st = json.loads(sf.read_text())
+            sm = get_state_summary(st)
+            detail = f" A:{sm.get('annual_ok',0)}/{sm.get('annual_ok',0)+sm.get('annual_skipped',0)} "
+            detail += f"Q:{sm.get('quarterly_ok',0)}/{sm.get('quarterly_ok',0)+sm.get('quarterly_skipped',0)} "
+            detail += f"I:{sm.get('ima_ok',0)}"
+            if sm.get("quarterly_failed",0)+sm.get("annual_failed",0)>0:
+                detail += f" ❌{sm['quarterly_failed']+sm['annual_failed']}"
+
+        print(f"  {marker} {code:15s} {s['name']:12s} {s['market']}  {detail}")
+
+    # 失败日志摘要
+    if FAIL_LOG.exists():
+        lines = FAIL_LOG.read_text().strip().split("\n")
+        recent = [l for l in lines if datetime.now(TZ_CN).strftime("%Y-%m-%d") in l]
+        if recent:
+            print(f"\n📋 今日失败记录 ({len(recent)} 条):")
+            for l in recent[-5:]:
+                print(f"  {l}")
+
+
+def show_detail(code: str = None):
+    """显示单只股票的详细状态"""
+    if not code:
+        print("Usage: --detail CODE")
+        return
+    sf = STATE_DIR / f"{code}.json"
+    if not sf.exists():
+        print(f"No state file for {code}")
+        return
+    st = json.loads(sf.read_text())
+    print(f"\n{'='*70}")
+    print(f"  {code}  {st.get('name','?')}  market={st.get('market','?')}")
+    print(f"  status={st.get('status','?')}  updated={st.get('updated_at','?')}")
+    if st.get('adr_source'): print(f"  ADR source: {st['adr_source']}")
+    if st.get('note'): print(f"  Note: {st['note']}")
+    print(f"{'='*70}")
+
+    # 年报
+    print(f"\n📊 年报:")
+    for y in sorted(st.get("annual",{}).keys(), reverse=True):
+        d = st["annual"][y]
+        icon = STATUS_ICONS.get(d.get("status",""), "?")
+        info = f"  {icon} {y} {d.get('status','')}"
+        if d.get("size"): info += f" ({d['size']//1024}KB)"
+        if d.get("ima"): info += f" IMA:{d['ima']}"
+        if d.get("reason"): info += f" — {d['reason'][:50]}"
+        print(info)
+
+    # 季报
+    print(f"\n📋 季报:")
+    for y in sorted(st.get("quarterly",{}).keys(), reverse=True):
+        for q, d in st["quarterly"][y].items():
+            icon = STATUS_ICONS.get(d.get("status",""), "?")
+            info = f"  {icon} {y} {q} {d.get('status','')}"
+            if d.get("size"): info += f" ({d['size']//1024}KB)"
+            if d.get("ima"): info += f" IMA:{d['ima']}"
+            if d.get("reason"): info += f" — {d['reason'][:50]}"
+            print(info)
+
+    # 汇总
+    sm = get_state_summary(st)
+    print(f"\n📈 Summary: A:{sm.get('annual_ok',0)}/{sm.get('annual_ok',0)+sm.get('annual_skipped',0)} "
+          f"Q:{sm.get('quarterly_ok',0)}/{sm.get('quarterly_ok',0)+sm.get('quarterly_skipped',0)} "
+          f"IMA:{sm.get('ima_ok',0)} Failed:{sm.get('annual_failed',0)+sm.get('quarterly_failed',0)}")
+
+
+def process_next():
+    if not QUEUE_FILE.exists():
+        print("ERROR: no queue. Run --init first."); sys.exit(1)
+    q = json.loads(QUEUE_FILE.read_text())
+    idx = next((i for i,s in enumerate(q["stocks"]) if s["status"]=="pending"), None)
+    if idx is None:
+        print("All done!")
+        show_status()
+        return
+
+    stock = q["stocks"][idx]
+    code, name, market = stock["code"], stock["name"], stock["market"]
+    stock["status"] = "processing"
+    q["pending"] = max(0, q["pending"]-1)
+    QUEUE_FILE.write_text(json.dumps(q, ensure_ascii=False, indent=2))
+
+    mflag = {"CN":"a","HK":"h","US":"m"}.get(market,"a")
+    clean_code = code.replace(".US","").replace(".SH","").replace(".SZ","").replace(".HK","")
+
+    print(f"\nProcessing: {code} ({name}) market={market}")
+    print(f"Progress: {q['done']}/{q['total']} done, {q['pending']} pending\n")
+
+    timed_out = False
+    returncode = 1
+    try:
+        rc = subprocess.run(["python3", str(SCRIPT), "--code", clean_code,
+                             "--market", mflag, "--name", name,
+                             "--annual-years", "10", "--quarterly-years", "5"],
+                            cwd=str(PROJECT_ROOT), timeout=3600)
+        returncode = rc.returncode
+    except TimeoutExpired:
+        timed_out = True
+        returncode = 124
+        print(f"\nTIMEOUT {code}: bulk_download exceeded 3600s")
+
+    # 同步状态文件
+    sf = _find_state(code)
+    st = None
+    if sf:
+        st = json.loads(sf.read_text())
+        if timed_out:
+            st["interrupted"] = {
+                "reason": "scheduler timeout",
+                "at": datetime.now(TZ_CN).isoformat(),
+            }
+            sf.write_text(json.dumps(st, ensure_ascii=False, indent=2))
+        sm = get_state_summary(st)
+        stock["annual_ok"] = sm.get("annual_ok",0)
+        stock["quarterly_ok"] = sm.get("quarterly_ok",0)
+        stock["failures"] = sm.get("annual_failed",0)+sm.get("quarterly_failed",0)
+        stock["summary_text"] = build_stock_summary(code, stock, st, timed_out=timed_out)
+
+    if returncode == 0:
+        stock["status"] = "done"; q["done"] += 1
+    else:
+        stock["status"] = "failed"; q["failed"] += 1
+        if timed_out:
+            stock["failure_reason"] = "timeout"
+
+    stock["updated_at"] = datetime.now(TZ_CN).isoformat()
+    q["last_updated"] = datetime.now(TZ_CN).isoformat()
+    QUEUE_FILE.write_text(json.dumps(q, ensure_ascii=False, indent=2))
+
+    print(f"\n{stock['status']} {code} | A:{stock['annual_ok']} Q:{stock['quarterly_ok']} F:{stock['failures']}")
+    if stock.get("summary_text"):
+        print(stock["summary_text"])
+    if q["pending"] <= 0:
+        show_status()
+
+
+def main():
+    if "--init" in sys.argv:
+        init_queue()
+    elif "--status" in sys.argv:
+        show_status()
+    elif "--detail" in sys.argv:
+        idx = sys.argv.index("--detail")+1
+        show_detail(sys.argv[idx] if idx<len(sys.argv) else None)
+    elif "--log" in sys.argv:
+        if LOG_FILE.exists():
+            print(LOG_FILE.read_text()[-5000:])
+        else:
+            print("No log yet")
+    else:
+        process_next()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_us_html_ima.py
+++ b/scripts/fix_us_html_ima.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Fix US annual filings that were marked uploaded while still being local HTML.
+
+For each affected annual entry in data/bulk_state/*.json:
+1. Re-download via unified_downloader with --pdf --no-cache so SEC HTML is converted to PDF.
+2. Upload the PDF to IMA.
+3. Update the per-stock state entry to the PDF path and real upload status.
+
+This is intentionally limited to existing US annual entries with HTML file refs; it does
+not do a full queue rerun and does not alter unrelated markets or pending stocks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
+QUEUE_FILE = PROJECT_ROOT / "data" / "bulk_download_queue.json"
+LOG_DIR = PROJECT_ROOT / "logs"
+FIX_LOG = LOG_DIR / "fix_us_html_ima.log"
+DEFAULT_IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
+IMA_SYNC_SCRIPT = Path(os.environ.get("IMA_SYNC_SCRIPT_PATH", DEFAULT_IMA_SYNC_SCRIPT))
+TZ_CN = timezone(timedelta(hours=8))
+
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[logging.FileHandler(FIX_LOG, encoding="utf-8"), logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger("fix_us_html_ima")
+
+
+def run(cmd: list[str], timeout: int) -> tuple[int, str, str]:
+    r = subprocess.run(cmd, cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=timeout)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def load_queue_names() -> dict[str, str]:
+    if not QUEUE_FILE.exists():
+        return {}
+    q = json.loads(QUEUE_FILE.read_text())
+    return {s["code"].replace(".US", ""): s.get("name", "") for s in q.get("stocks", []) if s.get("market") == "US"}
+
+
+def compute_summary(state: dict) -> dict:
+    s = {
+        "annual_ok": 0,
+        "annual_skipped": 0,
+        "annual_failed": 0,
+        "quarterly_ok": 0,
+        "quarterly_skipped": 0,
+        "quarterly_failed": 0,
+        "ima_ok": 0,
+        "ima_failed": 0,
+    }
+    for d in state.get("annual", {}).values():
+        st = d.get("status", "")
+        if st in ("downloaded", "uploaded"):
+            s["annual_ok"] += 1
+        elif st == "skipped":
+            s["annual_skipped"] += 1
+        elif "failed" in st:
+            s["annual_failed"] += 1
+        if d.get("ima") == "uploaded":
+            s["ima_ok"] += 1
+        elif d.get("ima") == "failed":
+            s["ima_failed"] += 1
+    for qs in state.get("quarterly", {}).values():
+        for d in qs.values():
+            st = d.get("status", "")
+            if st in ("downloaded", "uploaded"):
+                s["quarterly_ok"] += 1
+            elif st == "skipped":
+                s["quarterly_skipped"] += 1
+            elif "failed" in st:
+                s["quarterly_failed"] += 1
+            if d.get("ima") == "uploaded":
+                s["ima_ok"] += 1
+            elif d.get("ima") == "failed":
+                s["ima_failed"] += 1
+    return s
+
+
+def should_fix(state: dict, year: str, entry: dict) -> bool:
+    if state.get("market") != "US":
+        return False
+    f = entry.get("file", "")
+    if not f.lower().endswith((".html", ".htm")):
+        return False
+    return entry.get("status") in ("uploaded", "downloaded", "ima_failed") or entry.get("ima") == "uploaded"
+
+
+def convert_local_html(old_file: str) -> Path | None:
+    """Convert existing local SEC HTML to PDF without re-downloading."""
+    html = Path(old_file)
+    if not html.is_absolute():
+        html = PROJECT_ROOT / html
+    if not html.exists() or html.suffix.lower() not in (".html", ".htm"):
+        return None
+    pdf = html.with_suffix(".pdf")
+    if pdf.exists() and pdf.stat().st_size >= 100:
+        return pdf
+    try:
+        from unified_downloader.infra.converter import HTMLToPDFConverter
+        return HTMLToPDFConverter.convert(html, pdf_path=pdf, keep_original=True)
+    except Exception as e:
+        log.warning("local HTML→PDF failed old=%s err=%s", html, e)
+        return None
+
+
+def download_pdf(code: str, year: str, form_type: str) -> Path | None:
+    cmd = [
+        "python3", "-m", "unified_downloader.cli", "download", "single",
+        code, "-y", year, "-t", form_type, "-m", "m", "--pdf", "--no-cache",
+    ]
+    rc, out, err = run(cmd, timeout=240)
+    if rc != 0:
+        log.error("download failed code=%s year=%s form=%s rc=%s stdout=%s stderr=%s", code, year, form_type, rc, out[-600:], err[-600:])
+        return None
+    m = re.search(r"文件[：:]\s*(\S+)", out)
+    if not m:
+        log.error("download output missing file path code=%s year=%s stdout=%s", code, year, out[-600:])
+        return None
+    p = PROJECT_ROOT / m.group(1)
+    if not p.exists() or p.suffix.lower() != ".pdf" or p.stat().st_size < 100:
+        log.error("download invalid pdf code=%s year=%s path=%s exists=%s", code, year, p, p.exists())
+        return None
+    return p
+
+
+def upload_ima(pdf: Path, kb: str = "年报季度报知识库") -> bool:
+    rc, out, err = run(["bash", str(IMA_SYNC_SCRIPT), "--file", str(pdf), "--kb-name", kb, "--force"], timeout=360)
+    combined = out + "\n" + err
+    success_mark = ("✅" in combined or "已添加到知识库" in combined or "Upload successful" in combined)
+    skipped = ("跳过 " in combined or "skipped " in combined.lower()) and not success_mark
+    ok = rc == 0 and not skipped and success_mark
+    if not ok:
+        log.error("IMA upload failed file=%s rc=%s stdout=%s stderr=%s", pdf.name, rc, out[-800:], err[-800:])
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--code", action="append", help="Limit to base US ticker, e.g. AAPL. Can repeat.")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    wanted = {c.upper().replace(".US", "") for c in args.code or []}
+    names = load_queue_names()
+    targets: list[tuple[Path, str, str]] = []
+
+    for sf in sorted(STATE_DIR.glob("*.json")):
+        state = json.loads(sf.read_text())
+        code = state.get("code", sf.stem).upper().replace(".US", "")
+        if wanted and code not in wanted:
+            continue
+        if state.get("market") != "US":
+            continue
+        for year, entry in sorted(state.get("annual", {}).items(), reverse=True):
+            if should_fix(state, year, entry):
+                targets.append((sf, code, year))
+
+    log.info("targets=%d", len(targets))
+    if args.dry_run:
+        for sf, code, year in targets:
+            state = json.loads(sf.read_text())
+            log.info("DRY %s %s %s", code, year, state["annual"][year].get("file"))
+        return 0
+
+    ok = fail = 0
+    by_file: dict[Path, dict] = {}
+    for sf, code, year in targets:
+        state = by_file.get(sf)
+        if state is None:
+            state = json.loads(sf.read_text())
+            by_file[sf] = state
+
+        entry = state["annual"][year]
+        old_file = entry.get("file")
+        form = "20f" if "20F" in Path(old_file or "").name.upper() else "10k"
+        log.info("fix %s %s form=%s old=%s", code, year, form, old_file)
+        pdf = convert_local_html(old_file) or download_pdf(code, year, form)
+        if not pdf:
+            entry["status"] = "download_failed"
+            entry["ima"] = "failed"
+            entry["reason"] = "PDF conversion/download failed during US HTML IMA fix"
+            fail += 1
+        elif upload_ima(pdf):
+            entry["status"] = "uploaded"
+            entry["ima"] = "uploaded"
+            entry["file"] = str(pdf)
+            entry["size"] = pdf.stat().st_size
+            entry["fixed_from"] = old_file
+            entry["fixed_at"] = datetime.now(TZ_CN).isoformat()
+            entry.pop("reason", None)
+            ok += 1
+            log.info("ok %s %s -> %s", code, year, pdf.name)
+        else:
+            entry["status"] = "ima_failed"
+            entry["ima"] = "failed"
+            entry["file"] = str(pdf)
+            entry["size"] = pdf.stat().st_size
+            entry["reason"] = "PDF generated but IMA upload failed during US HTML IMA fix"
+            fail += 1
+
+        state["summary"] = compute_summary(state)
+        state["status"] = "partial_failure" if state["summary"]["ima_failed"] or state["summary"]["annual_failed"] else "ok"
+        state["updated_at"] = datetime.now(TZ_CN).isoformat()
+        state["name"] = state.get("name") or names.get(code, "")
+        sf.write_text(json.dumps(state, ensure_ascii=False, indent=2))
+
+    log.info("done ok=%d fail=%d", ok, fail)
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bulk_download_us_quarterly.py
+++ b/tests/test_bulk_download_us_quarterly.py
@@ -126,3 +126,31 @@ def test_set_doc_status_persists_quarterly_form_type_for_fallback_protection():
     assert entry["ima"] == "failed"
     assert bulk.should_mark_quarterly_unavailable(state, "2025", "Q1-Q3", "6k") is False
     assert bulk.should_mark_quarterly_unavailable(state, "2025", "Q1-Q3", "10q") is True
+
+
+def test_download_one_us_uses_pdf_without_disabling_cache(monkeypatch, tmp_path):
+    bulk = load_bulk_module()
+    bulk.log = __import__("logging").getLogger("test-bulk")
+    output = tmp_path / "downloads/m/AAP/AAPL_2025_10Q.pdf"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(b"%PDF-1.4\n" + b"x" * 128)
+    rel = output.relative_to(tmp_path)
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+    calls = []
+
+    def fake_run(cmd, timeout=120):
+        calls.append(cmd)
+        return 0, f"✓ 下载成功\n  文件: {rel}", ""
+
+    monkeypatch.setattr(bulk, "run", fake_run)
+
+    assert bulk.download_one("AAPL", "US", "2025", "10q") == output
+    assert "--pdf" in calls[0]
+    assert "--no-cache" not in calls[0]
+
+
+def test_ima_sync_script_path_can_be_overridden(monkeypatch):
+    monkeypatch.setenv("IMA_SYNC_SCRIPT_PATH", "/tmp/custom-sync-to-ima.sh")
+    bulk = load_bulk_module()
+
+    assert str(bulk.IMA_SYNC_SCRIPT) == "/tmp/custom-sync-to-ima.sh"


### PR DESCRIPTION
## Summary
- remove hardcoded repo path from the bulk script docstring
- allow overriding the IMA sync script via `IMA_SYNC_SCRIPT_PATH` in bulk/fix scripts
- initialize `log` with `logging.getLogger("bulk")` instead of `None`, so helpers are safer in direct tests/use
- stop forcing `--no-cache` for normal US bulk downloads; PR #19 fixed cache-hit + `--pdf`, so SEC cache reuse is now safe
- add the operational bulk maintenance scripts:
  - `scripts/bulk_scheduler.py`
  - `scripts/fix_us_html_ima.py`
- add regression tests for US command flags and IMA sync path override

## Double-check / Verification
- `python3 -m py_compile scripts/bulk_download.py scripts/bulk_scheduler.py scripts/fix_us_html_ima.py tests/test_bulk_download_us_quarterly.py`
- `python3 -m pytest tests/test_bulk_download_us_quarterly.py tests/test_us_cache_semantic_filename.py -q` → 13 passed
- `python3 scripts/bulk_scheduler.py --status` → read-only status rendering OK
- `python3 scripts/fix_us_html_ima.py --dry-run --code __NO_SUCH_CODE__` → dry-run exits OK with targets=0
- Imported both new scripts via `importlib.util.spec_from_file_location(...)` successfully
- `git diff --check` passed

## Notes
- Addresses issue #22 suggestions 2, 4, and 5.
- Suggestion 3 (retry backoff/cooldown) is intentionally not included because it changes operational retry policy and should be designed separately.
- Suggestion 6 (ruff cosmetic cleanup) is intentionally not included to avoid a noisy style-only diff over the runtime script.
- `fix_us_html_ima.py` intentionally keeps `--no-cache` in its one-off repair path: it is specifically fixing old local HTML states and must not be short-circuited by an HTML cache hit.
