### PR TITLE
fix: decouple bulk scheduler queue init

### DIFF
--- a/scripts/bulk_scheduler.py
+++ b/scripts/bulk_scheduler.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-import json, subprocess, sys
+import argparse, json, os, subprocess, sys
 from subprocess import TimeoutExpired
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -29,30 +29,108 @@ STATUS_ICONS = {
 DEDUP_US = {"TCEHY.US", "BEKE.US", "HTHT.US"}
 
 
-def init_queue():
-    sys.path.insert(0, str(Path.home() / "code" / "morning-brief"))
-    from src.utils.database import get_connection
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute("SELECT stock_code,stock_name,market FROM watchlist WHERE is_active=1 AND is_index=0 ORDER BY market,stock_code")
-    rows = cur.fetchall()
-    conn.close()
+def _normalize_watchlist_rows(rows: list) -> list[tuple[str, str, str]]:
+    """Normalize watchlist rows from JSON or external providers."""
+    normalized = []
+    for item in rows:
+        if isinstance(item, dict):
+            code = item.get("code") or item.get("stock_code") or item.get("symbol")
+            name = item.get("name") or item.get("stock_name") or ""
+            market = item.get("market")
+        else:
+            code, name, market = item[:3]
+        if not code or not market:
+            raise SystemExit(
+                "Invalid watchlist row. Expected code/name/market fields, "
+                f"got: {item!r}"
+            )
+        normalized.append((str(code), str(name), str(market).upper()))
+    return normalized
 
+
+def load_watchlist_file(path: str | Path) -> list[tuple[str, str, str]]:
+    """Load watchlist rows from an explicit JSON file.
+
+    Supported JSON shapes:
+    - [{"code": "AAPL.US", "name": "Apple", "market": "US"}, ...]
+    - {"stocks": [{"stock_code": "600519.SH", "stock_name": "贵州茅台", "market": "CN"}]}
+    """
+    watchlist_path = Path(path).expanduser()
+    if not watchlist_path.exists():
+        raise SystemExit(f"watchlist file not found: {watchlist_path}")
+    data = json.loads(watchlist_path.read_text(encoding="utf-8"))
+    rows = data.get("stocks", data) if isinstance(data, dict) else data
+    if not isinstance(rows, list):
+        raise SystemExit("watchlist JSON must be a list or an object with a 'stocks' list")
+    return _normalize_watchlist_rows(rows)
+
+
+def load_watchlist_from_morning_brief(path: str | Path | None = None) -> list[tuple[str, str, str]]:
+    """Opt-in compatibility loader for a local morning-brief checkout."""
+    raw_path = str(path or os.environ.get("MORNING_BRIEF_PATH", "")).strip()
+    if not raw_path:
+        raise SystemExit(
+            "--from-morning-brief requires --morning-brief-path or MORNING_BRIEF_PATH. "
+            "Prefer --watchlist-file for a decoupled queue source."
+        )
+    mb_path = Path(raw_path).expanduser()
+    if not mb_path.exists():
+        raise SystemExit(
+            f"morning-brief not found at {mb_path}. Set MORNING_BRIEF_PATH, "
+            "pass --morning-brief-path, or use --watchlist-file."
+        )
+    sys.path.insert(0, str(mb_path))
+    try:
+        from src.utils.database import get_connection
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            f"Cannot import morning-brief database helper from {mb_path}: {exc}. "
+            "Use --watchlist-file to avoid cross-repo imports."
+        ) from exc
+    conn = get_connection()
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT stock_code,stock_name,market FROM watchlist WHERE is_active=1 AND is_index=0 ORDER BY market,stock_code")
+        return _normalize_watchlist_rows(cur.fetchall())
+    finally:
+        conn.close()
+
+
+def build_queue(rows: list[tuple[str, str, str]]) -> list[dict]:
     queue = []
     for code, name, market in rows:
-        if market == "US" and code in DEDUP_US:
+        if market == "US" and code.upper() in DEDUP_US:
             continue
-        queue.append({"code":code,"name":name,"market":market,"status":"pending",
-                       "annual_ok":0,"quarterly_ok":0,"failures":0})
+        queue.append({"code": code, "name": name, "market": market, "status": "pending",
+                       "annual_ok": 0, "quarterly_ok": 0, "failures": 0})
+    return queue
+
+
+def write_queue(queue: list[dict]) -> None:
     QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
     QUEUE_FILE.write_text(json.dumps({
         "created_at": datetime.now(TZ_CN).isoformat(),
-        "total":len(queue),"pending":len(queue),"done":0,"failed":0,
-        "stocks":queue
+        "total": len(queue), "pending": len(queue), "done": 0, "failed": 0,
+        "stocks": queue,
     }, ensure_ascii=False, indent=2))
     print(f"Queue: {len(queue)} stocks (CN:{sum(1 for s in queue if s['market']=='CN')} "
           f"HK:{sum(1 for s in queue if s['market']=='HK')} "
           f"US:{sum(1 for s in queue if s['market']=='US')})")
+
+
+def init_queue(watchlist_file: str | None = None, from_morning_brief: bool = False,
+               morning_brief_path: str | None = None):
+    if watchlist_file:
+        rows = load_watchlist_file(watchlist_file)
+    elif from_morning_brief:
+        rows = load_watchlist_from_morning_brief(morning_brief_path)
+    else:
+        raise SystemExit(
+            "Queue source required. Use --init --watchlist-file FILE.json, or "
+            "opt in to the legacy cross-repo source with --init --from-morning-brief "
+            "--morning-brief-path PATH (or MORNING_BRIEF_PATH)."
+        )
+    write_queue(build_queue(rows))
 
 
 def _find_state(code: str) -> Path | None:
@@ -305,14 +383,23 @@ def process_next():
 
 
 def main():
-    if "--init" in sys.argv:
-        init_queue()
-    elif "--status" in sys.argv:
+    parser = argparse.ArgumentParser(description="Bulk download scheduler")
+    parser.add_argument("--init", action="store_true", help="Initialize queue from an explicit source")
+    parser.add_argument("--watchlist-file", help="JSON watchlist file for --init")
+    parser.add_argument("--from-morning-brief", action="store_true", help="Opt in to loading watchlist from a local morning-brief checkout")
+    parser.add_argument("--morning-brief-path", help="Path to morning-brief checkout; alternatively set MORNING_BRIEF_PATH")
+    parser.add_argument("--status", action="store_true", help="Show queue status")
+    parser.add_argument("--detail", help="Show detailed state for one code")
+    parser.add_argument("--log", action="store_true", help="Show recent bulk log")
+    args = parser.parse_args()
+
+    if args.init:
+        init_queue(args.watchlist_file, args.from_morning_brief, args.morning_brief_path)
+    elif args.status:
         show_status()
-    elif "--detail" in sys.argv:
-        idx = sys.argv.index("--detail")+1
-        show_detail(sys.argv[idx] if idx<len(sys.argv) else None)
-    elif "--log" in sys.argv:
+    elif args.detail:
+        show_detail(args.detail)
+    elif args.log:
         if LOG_FILE.exists():
             print(LOG_FILE.read_text()[-5000:])
         else:

--- a/tests/test_bulk_scheduler.py
+++ b/tests/test_bulk_scheduler.py
@@ -1,0 +1,89 @@
+"""Regression tests for bulk scheduler queue initialization."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def load_scheduler():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "bulk_scheduler.py"
+    spec = importlib.util.spec_from_file_location("bulk_scheduler_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_init_queue_requires_explicit_source(tmp_path, monkeypatch):
+    scheduler = load_scheduler()
+    monkeypatch.setattr(scheduler, "QUEUE_FILE", tmp_path / "queue.json")
+
+    with pytest.raises(SystemExit) as exc:
+        scheduler.init_queue()
+
+    assert "Queue source required" in str(exc.value)
+    assert not scheduler.QUEUE_FILE.exists()
+
+
+def test_init_queue_from_watchlist_file_writes_normalized_queue(tmp_path, monkeypatch):
+    scheduler = load_scheduler()
+    queue_file = tmp_path / "data" / "bulk_download_queue.json"
+    monkeypatch.setattr(scheduler, "QUEUE_FILE", queue_file)
+    watchlist = tmp_path / "watchlist.json"
+    watchlist.write_text(
+        json.dumps(
+            {
+                "stocks": [
+                    {"stock_code": "600519.SH", "stock_name": "贵州茅台", "market": "cn"},
+                    {"code": "AAPL.US", "name": "Apple", "market": "US"},
+                    {"code": "TCEHY.US", "name": "Tencent ADR", "market": "US"},
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    scheduler.init_queue(watchlist_file=str(watchlist))
+
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    assert payload["total"] == 2
+    assert payload["pending"] == 2
+    assert [s["code"] for s in payload["stocks"]] == ["600519.SH", "AAPL.US"]
+    assert payload["stocks"][0]["market"] == "CN"
+
+
+def test_morning_brief_loader_is_opt_in_and_has_actionable_error(monkeypatch):
+    scheduler = load_scheduler()
+    monkeypatch.delenv("MORNING_BRIEF_PATH", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        scheduler.load_watchlist_from_morning_brief()
+
+    assert "--from-morning-brief requires" in str(exc.value)
+    assert "--watchlist-file" in str(exc.value)
+
+
+def test_show_status_remains_read_only_for_existing_queue(tmp_path, monkeypatch, capsys):
+    scheduler = load_scheduler()
+    queue_file = tmp_path / "queue.json"
+    queue_file.write_text(
+        json.dumps({"total": 1, "done": 0, "failed": 0, "pending": 1, "stocks": [
+            {"code": "AAPL.US", "name": "Apple", "market": "US", "status": "pending"}
+        ]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(scheduler, "QUEUE_FILE", queue_file)
+    monkeypatch.setattr(scheduler, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(scheduler, "FAIL_LOG", tmp_path / "failures.log")
+
+    before = queue_file.read_text(encoding="utf-8")
+    scheduler.show_status()
+    after = queue_file.read_text(encoding="utf-8")
+
+    assert before == after
+    assert "AAPL.US" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- remove the implicit `~/code/morning-brief` import from default `--init`
- require an explicit queue source:
  - preferred: `--init --watchlist-file FILE.json`
  - compatibility opt-in: `--init --from-morning-brief --morning-brief-path PATH` or `MORNING_BRIEF_PATH`
- add actionable `SystemExit` messages instead of raw `ModuleNotFoundError`
- support JSON watchlist shapes with either `code/name/market` or `stock_code/stock_name/market`
- add regression tests for explicit source requirement, JSON init, morning-brief opt-in error, and read-only status rendering
- remove duplicate quarterly heading in `show_detail`

## Verification
- `python3 -m py_compile scripts/bulk_scheduler.py`
- `python3 -m pytest tests/test_bulk_scheduler.py tests/test_bulk_download_us_quarterly.py tests/test_us_cache_semantic_filename.py -q` → 21 passed
- `python3 scripts/bulk_scheduler.py --init` now fails with actionable queue-source guidance instead of importing morning-brief
- `python3 scripts/bulk_scheduler.py --status` still renders existing queue read-only
- `git diff --check` passed

Fixes #26.
