### PR TITLE
feat: USFormResolver protocol — replace private call with typed dispatch

### DIFF
--- a/tests/test_us_cache_semantic_filename.py
+++ b/tests/test_us_cache_semantic_filename.py
@@ -21,7 +21,7 @@ def test_us_cache_hit_restores_semantic_download_filename(tmp_path, monkeypatch)
 
     monkeypatch.setattr(
         downloader._adapters[Market.M],
-        "_get_annual_form_type",
+        "get_annual_form_type",
         lambda code: "10-K",
     )
 
@@ -47,7 +47,7 @@ def test_us_cache_hit_with_pdf_request_ignores_cached_html(tmp_path, monkeypatch
 
     monkeypatch.setattr(
         downloader._adapters[Market.M],
-        "_get_annual_form_type",
+        "get_annual_form_type",
         lambda code: "10-K",
     )
 
@@ -82,7 +82,7 @@ def test_us_annual_report_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
     downloader = UnifiedDownloader()
     monkeypatch.setattr(
         downloader._adapters[Market.M],
-        "_get_annual_form_type",
+        "get_annual_form_type",
         lambda code: "20-F",
     )
 
@@ -104,7 +104,7 @@ def test_us_quarterly_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
     downloader = UnifiedDownloader()
     monkeypatch.setattr(
         downloader._adapters[Market.M],
-        "_get_quarterly_form_type",
+        "get_quarterly_form_type",
         lambda code: "6-K",
     )
 
@@ -126,7 +126,7 @@ def test_us_cache_hit_exposes_original_cache_path_metadata(tmp_path, monkeypatch
     downloader = UnifiedDownloader()
     monkeypatch.setattr(
         downloader._adapters[Market.M],
-        "_get_annual_form_type",
+        "get_annual_form_type",
         lambda code: "10-K",
     )
 
@@ -147,7 +147,7 @@ def test_us_cache_hit_does_not_recopied_existing_semantic_file(tmp_path, monkeyp
     downloader = UnifiedDownloader()
     monkeypatch.setattr(
         downloader._adapters[Market.M],
-        "_get_annual_form_type",
+        "get_annual_form_type",
         lambda code: "10-K",
     )
 
@@ -179,7 +179,7 @@ async def test_async_us_cache_hit_restores_semantic_filename(tmp_path, monkeypat
     downloader = AsyncUnifiedDownloader()
     monkeypatch.setattr(
         downloader._downloader._adapters[Market.M],
-        "_get_annual_form_type",
+        "get_annual_form_type",
         lambda code: "10-K",
     )
 

--- a/unified_downloader/adapters/__init__.py
+++ b/unified_downloader/adapters/__init__.py
@@ -1,12 +1,13 @@
 """Adapters package"""
 
-from unified_downloader.adapters.base import BaseStockAdapter
+from unified_downloader.adapters.base import BaseStockAdapter, USFormResolver
 from unified_downloader.adapters.a_stock import AStockAdapter
 from unified_downloader.adapters.m_stock import MStockAdapter
 from unified_downloader.adapters.h_stock import HStockAdapter
 
 __all__ = [
     "BaseStockAdapter",
+    "USFormResolver",
     "AStockAdapter",
     "MStockAdapter",
     "HStockAdapter",

--- a/unified_downloader/adapters/base.py
+++ b/unified_downloader/adapters/base.py
@@ -1,12 +1,32 @@
 """适配器基类"""
 
 from abc import ABC, abstractmethod
-from typing import Optional, List, Dict, Any, Callable
+from typing import Optional, List, Dict, Any, Callable, Protocol, runtime_checkable
 from pathlib import Path
 
 from unified_downloader.models.enums import Market
 from unified_downloader.models.entities import DownloadResult, DataSource
 from unified_downloader.infra.http_client import HTTPClient, AsyncHTTPClient
+
+
+@runtime_checkable
+class USFormResolver(Protocol):
+    """协议：US adapter 公开暴露的 SEC form type 解析接口。
+
+    任何实现这两个方法的 adapter 都会被 `UnifiedDownloader` 当作可解析
+    US semantic form type 的目标 — 替代原先的 `hasattr(adapter, "_get_...")`
+    鸭子类型 + `# type: ignore[attr-defined]` 调用模式。
+
+    实现：见 `unified_downloader.adapters.m_stock.MStockAdapter`。
+    """
+
+    def get_annual_form_type(self, code: str) -> str:
+        """返回年报的 SEC 表格类型（'10-K' 或 '20-F'）"""
+        ...
+
+    def get_quarterly_form_type(self, code: str) -> str:
+        """返回季报的 SEC 表格类型（'10-Q' 或 '6-K'）"""
+        ...
 
 
 class BaseStockAdapter(ABC):

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -455,14 +455,16 @@ class MStockAdapter(BaseStockAdapter):
         **kwargs,
     ) -> DownloadResult:
         """下载年度报告：FPI用20-F，本土用10-K"""
-        form_type = self._get_annual_form_type(code)
+        form_type = self.get_annual_form_type(code)
         return self._download_form(code, form_type, year, checkpoint, on_progress)
 
-    def _get_annual_form_type(self, code: str) -> str:
+    def get_annual_form_type(self, code: str) -> str:
         """判断公司的年度报告SEC归档表格类型。
-        
+
         外国私人发行人(FPI)如中概股/ADR，年度用20-F
         美国本土公司用10-K
+
+        作为 USFormResolver 协议成员被 UnifiedDownloader 跨模块调用。
         """
         try:
             if self._init_edgar():
@@ -485,14 +487,16 @@ class MStockAdapter(BaseStockAdapter):
         **kwargs,
     ) -> DownloadResult:
         """下载季度报告：外国私人发行人(FPI)使用6-K，美国本土公司使用10-Q"""
-        form_type = self._get_quarterly_form_type(code)
+        form_type = self.get_quarterly_form_type(code)
         return self._download_form(code, form_type, year, checkpoint, on_progress)
 
-    def _get_quarterly_form_type(self, code: str) -> str:
+    def get_quarterly_form_type(self, code: str) -> str:
         """判断公司的季度报告SEC归档表格类型。
-        
+
         外国私人发行人(Foreign Private Issuer)如中概股，季度用6-K
-        美国本土公司用10-Q
+        美国本土公司使用10-Q
+
+        作为 USFormResolver 协议成员被 UnifiedDownloader 跨模块调用。
         """
         try:
             if self._init_edgar():
@@ -812,7 +816,7 @@ class MStockAdapter(BaseStockAdapter):
         on_progress: Optional[Callable],
     ) -> DownloadResult:
         """异步下载年度报告：FPI用20-F，本土用10-K"""
-        form_type = self._get_annual_form_type(code)
+        form_type = self.get_annual_form_type(code)
         return await self._async_download_form(http_client, code, form_type, year, checkpoint, on_progress)
 
     async def _async_download_10q(
@@ -825,7 +829,7 @@ class MStockAdapter(BaseStockAdapter):
         on_progress: Optional[Callable],
     ) -> DownloadResult:
         """异步下载季度报告：FPI用6-K，本土用10-Q"""
-        form_type = self._get_quarterly_form_type(code)
+        form_type = self.get_quarterly_form_type(code)
         return await self._async_download_form(http_client, code, form_type, year, checkpoint, on_progress)
 
     async def _async_download_s1(

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -22,6 +22,7 @@ from unified_downloader.adapters import (
     MStockAdapter,
     HStockAdapter,
     BaseStockAdapter,
+    USFormResolver,
 )
 from unified_downloader.infra import (
     HTTPClient,
@@ -370,27 +371,20 @@ class UnifiedDownloader:
         ticker = code.upper()
         doc_label = self._semantic_us_doc_label(document_type)
         adapter = self._adapters.get(Market.M)
-        normalized = document_type.lower().replace("-", "_")
-        try:
-            if normalized in ("annual_report", "10k", "ten_k") and hasattr(
-                adapter, "_get_annual_form_type"
-            ):
-                doc_label = self._semantic_us_doc_label(
-                    adapter._get_annual_form_type(ticker)  # type: ignore[attr-defined]
+        if isinstance(adapter, USFormResolver):
+            normalized = document_type.lower().replace("-", "_")
+            try:
+                if normalized in ("annual_report", "10k", "ten_k"):
+                    doc_label = self._semantic_us_doc_label(adapter.get_annual_form_type(ticker))
+                elif normalized in ("quarterly", "10q", "ten_q"):
+                    doc_label = self._semantic_us_doc_label(adapter.get_quarterly_form_type(ticker))
+            except Exception as exc:
+                logger.debug(
+                    "Failed to resolve US semantic form type for %s %s: %s",
+                    ticker,
+                    document_type,
+                    exc,
                 )
-            elif normalized in ("quarterly", "10q", "ten_q") and hasattr(
-                adapter, "_get_quarterly_form_type"
-            ):
-                doc_label = self._semantic_us_doc_label(
-                    adapter._get_quarterly_form_type(ticker)  # type: ignore[attr-defined]
-                )
-        except Exception as exc:
-            logger.debug(
-                "Failed to resolve US semantic form type for %s %s: %s",
-                ticker,
-                document_type,
-                exc,
-            )
 
         base_dir = Path("downloads") / market.value / ticker[:3]
         if year is None:


### PR DESCRIPTION
## Summary

Resolves #29 item 1 (cross-module call to private adapter method) by introducing a runtime-checkable `USFormResolver` Protocol and renaming MStockAdapter's two `_get_*` form-type methods to public `get_*`.

## Changes

- **Add `USFormResolver` Protocol** in `unified_downloader/adapters/base.py` — runtime-checkable, declares the two `get_*` form-type resolution methods
- **Re-export from `adapters/__init__.py`** so `from unified_downloader.adapters import USFormResolver` works
- **Rename `MStockAdapter._get_annual_form_type` → `get_annual_form_type`** (公开)
- **Rename `MStockAdapter._get_quarterly_form_type` → `get_quarterly_form_type`** (公开)
- **Update 4 internal call sites** in m_stock.py (2 sync + 2 async download paths)
- **Replace `hasattr` + `# type: ignore[attr-defined]`** in downloader.py with `isinstance(adapter, USFormResolver)` gating
- **Update 7 test mock targets** in `test_us_cache_semantic_filename.py` from old to new method names

## Out of scope (kept for follow-up)

- #22-3 retry backoff (`attempts` counter + cooldown) — needs state schema change + dedicated tests + interaction with fallback routing logic. Worth its own PR.
- #21-1 redundant Market.M nesting, #22-1 form_type persistence, etc. — already resolved in earlier PRs (#19/#20/#23)

## Verification

```
$ python3 -m pytest tests/ -q
25 passed, 50 warnings in 0.54s

$ ruff check scripts/bulk_download.py
All checks passed!
```

Refs #29