### PR TITLE
feat: add IPO prospectus download support for A-shares, US stocks, and HK stocks

### DIFF
--- a/unified_downloader/adapters/a_stock.py
+++ b/unified_downloader/adapters/a_stock.py
@@ -93,6 +93,97 @@ class CninfoAPI:
 
         return None
 
+    # 全文检索 API 端点
+    FULLTEXT_SEARCH_URL = "http://www.cninfo.com.cn/new/hisAnnouncement/query"
+
+    @staticmethod
+    def search_fulltext(
+        keyword: str,
+        se_date: Optional[str] = None,
+        page_num: int = 1,
+        page_size: int = 30,
+        http_client: Optional[HTTPClient] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        巨潮资讯全文检索
+
+        POST http://www.cninfo.com.cn/new/hisAnnouncement/query
+
+        Args:
+            keyword: 搜索关键词，如 "贵州茅台 招股说明书"
+            se_date: 日期范围 "YYYY-MM-DD~YYYY-MM-DD"，None 表示不限
+            page_num: 页码
+            page_size: 每页条数
+            http_client: HTTP 客户端，None 则创建临时实例
+
+        Returns:
+            标准化文档列表:
+            [{title, date, file_size, url, source: "cninfo", code, name}, ...]
+        """
+        import requests
+        from datetime import datetime
+
+        if http_client is None:
+            session = requests.Session()
+        else:
+            session = http_client.session
+
+        payload = {
+            "searchkey": keyword,
+            "pageNum": page_num,
+            "pageSize": page_size,
+        }
+        if se_date:
+            payload["seDate"] = se_date
+
+        try:
+            if http_client is not None:
+                resp = http_client.post(
+                    CninfoAPI.FULLTEXT_SEARCH_URL,
+                    data=payload,
+                    headers={"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"},
+                )
+            else:
+                resp = session.post(
+                    CninfoAPI.FULLTEXT_SEARCH_URL,
+                    data=payload,
+                    headers={"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"},
+                    timeout=30,
+                )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.error(f"全文检索失败: {e}")
+            return []
+
+        announcements = data.get("announcements") or []
+        results = []
+        for item in announcements:
+            # announcementTime 是 int 毫秒时间戳
+            ts = item.get("announcementTime", 0)
+            try:
+                dt = datetime.fromtimestamp(ts / 1000)
+                date_str = dt.strftime("%Y-%m-%d")
+            except (ValueError, OSError):
+                date_str = ""
+
+            adjunct_url = item.get("adjunctUrl", "")
+            url = ""
+            if adjunct_url:
+                url = f"https://static.cninfo.com.cn/{adjunct_url}"
+
+            results.append({
+                "title": item.get("announcementTitle", ""),
+                "date": date_str,
+                "file_size": item.get("adjunctSize", 0),
+                "url": url,
+                "source": "cninfo",
+                "code": item.get("secCode", ""),
+                "name": item.get("secName", ""),
+            })
+
+        return results
+
     @staticmethod
     def download_pdf(pdf_url: str, save_path: str, http_client: HTTPClient) -> bool:
         """
@@ -170,6 +261,10 @@ class AStockAdapter(BaseStockAdapter):
             return self._download_quarterly_report(
                 code, year, datasource, checkpoint, on_progress
             )
+        elif doc_type_lower in ["prospectus", "招股说明书", "招股书", "s1"]:
+            return self._download_prospectus(
+                code, datasource, checkpoint, on_progress
+            )
         else:
             return self._download_annual_report(
                 code, year, datasource, checkpoint, on_progress
@@ -242,6 +337,106 @@ class AStockAdapter(BaseStockAdapter):
                 code, year, "三季报", "quarterly_report", checkpoint, on_progress
             )
         return result
+
+    def _download_prospectus(
+        self,
+        code: str,
+        datasource: Optional[DataSource],
+        checkpoint: Optional[Dict[str, Any]],
+        on_progress: Optional[Callable],
+    ) -> DownloadResult:
+        """下载招股说明书
+
+        使用巨潮资讯全文检索 API 搜索招股书，按时间倒序取最新一份下载。
+        """
+        symbol = code.strip().upper()
+        if symbol.startswith("SH"):
+            symbol = symbol[2:]
+        elif symbol.startswith("SZ"):
+            symbol = symbol[2:]
+
+        # 搜索招股书：用代码+招股说明书关键词
+        keyword = f"{symbol} 招股说明书"
+        self._rate_limiter.wait()
+        try:
+            docs = CninfoAPI.search_fulltext(
+                keyword=keyword,
+                http_client=self._http_client,
+            )
+        except Exception as e:
+            logger.error(f"搜索招股书失败: {e}")
+            return DownloadResult(
+                success=False,
+                error_code="SEARCH_ERROR",
+                error_message=f"搜索招股书失败: {e}",
+            )
+
+        if not docs:
+            return DownloadResult(
+                success=False,
+                error_code="NO_FILINGS_FOUND",
+                error_message=f"未找到 {symbol} 的招股说明书",
+            )
+
+        # 选最佳匹配：优先标题含"招股说明书"且不含"附录/摘要/意见"的
+        primary = [
+            d for d in docs
+            if "招股说明书" in d["title"]
+            and not any(kw in d["title"] for kw in ["附录", "摘要", "意见", "补充"])
+        ]
+        candidates = primary if primary else docs
+
+        # 在候选中选文件最大的（通常是完整版招股书）
+        doc = max(candidates, key=lambda d: d.get("file_size", 0))
+
+        url = doc.get("url", "")
+        if not url:
+            return DownloadResult(
+                success=False,
+                error_code="URL_NOT_FOUND",
+                error_message="无法获取招股书 PDF 下载链接",
+            )
+
+        # 解析年份
+        file_year = None
+        date_str = doc.get("date", "")
+        if date_str:
+            try:
+                file_year = int(date_str[:4])
+            except (ValueError, TypeError):
+                pass
+
+        # 构建保存路径
+        file_path = self._build_file_path(
+            symbol.zfill(6), file_year, "PROSPECTUS", ".PDF"
+        )
+
+        # 下载 PDF
+        try:
+            result = self._http_client.download_file(
+                url, file_path, on_progress=on_progress, checkpoint=checkpoint
+            )
+
+            return DownloadResult(
+                success=True,
+                file_path=result["file_path"],
+                file_size=result["file_size"],
+                source="cninfo",
+                metadata={
+                    "symbol": symbol,
+                    "title": doc.get("title", ""),
+                    "date": doc.get("date", ""),
+                    "name": doc.get("name", ""),
+                },
+            )
+
+        except Exception as e:
+            logger.error(f"下载招股书失败: {e}")
+            return DownloadResult(
+                success=False,
+                error_code="DOWNLOAD_ERROR",
+                error_message=f"下载招股书失败: {e}",
+            )
 
     def _download_report(
         self,
@@ -387,6 +582,19 @@ class AStockAdapter(BaseStockAdapter):
                 category = "一季报"
             elif "q3" in doc_type_lower:
                 category = "三季报"
+            elif "prospectus" in doc_type_lower or "招股" in doc_type_lower:
+                # 招股书使用全文检索 API
+                self._rate_limiter.wait()
+                keyword = f"{symbol} 招股说明书"
+                if year:
+                    se_date = f"{year}-01-01~{year}-12-31"
+                else:
+                    se_date = None
+                return CninfoAPI.search_fulltext(
+                    keyword=keyword,
+                    se_date=se_date,
+                    http_client=self._http_client,
+                )
 
         self._rate_limiter.wait()
         try:

--- a/unified_downloader/adapters/h_stock.py
+++ b/unified_downloader/adapters/h_stock.py
@@ -392,7 +392,11 @@ class HStockAdapter(BaseStockAdapter):
         return DownloadResult(
             success=False,
             error_code="NO_FILINGS_FOUND",
-            error_message=f"未找到 {stock_code} 的招股书（该股票可能未在港交所上市或提交招股书）",
+            error_message=(
+                f"未找到 {stock_code} 的招股书。"
+                f"该股票可能上市时间较早（>10年），招股书不在港交所披露易系统中，"
+                f"或该股票尚未在港交所上市。"
+            ),
         )
 
     @staticmethod
@@ -420,11 +424,16 @@ class HStockAdapter(BaseStockAdapter):
     ) -> DownloadResult:
         """从搜索结果文档下载文件"""
         file_link = doc.get("file_link", "")
-        if not file_link:
+        file_info = doc.get("file_info", "")
+        if not file_link or "多檔案" in file_info:
             return DownloadResult(
                 success=False,
-                error_code="URL_NOT_FOUND",
-                error_message="无法获取文档链接",
+                error_code="MULTI_FILE",
+                error_message=(
+                    "该招股书为多檔案类型，无法直接下载 PDF。"
+                    "请访问港交所披露易网页查看: "
+                    "https://www1.hkexnews.hk/search/titlesearch.xhtml"
+                ),
             )
 
         ext = ".pdf" if file_link.lower().endswith(".pdf") else ".html"

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -1,5 +1,6 @@
 """美股适配器 - 使用 edgartools (主) + sec-api (兜底)"""
 
+import asyncio
 import logging
 import os
 import time
@@ -136,8 +137,8 @@ class MStockAdapter(BaseStockAdapter):
             return self._download_10k(code, year, datasource, checkpoint, on_progress, **kwargs)
         elif doc_type_lower in ["10q", "ten_q"]:
             return self._download_10q(code, year, datasource, checkpoint, on_progress, **kwargs)
-        elif doc_type_lower in ["s1", "s1a", "prospectus"]:
-            return self._download_s1(
+        elif doc_type_lower in ["s1", "s1a", "f1", "424b4", "prospectus"]:
+            return self._download_prospectus(
                 code, document_type, datasource, checkpoint, on_progress
             )
         elif doc_type_lower in ["6k", "8k"]:
@@ -169,8 +170,8 @@ class MStockAdapter(BaseStockAdapter):
             return await self._async_download_10q(
                 http_client, code, year, datasource, checkpoint, on_progress, **kwargs
             )
-        elif doc_type_lower in ["s1", "s1a", "prospectus"]:
-            return await self._async_download_s1(
+        elif doc_type_lower in ["s1", "s1a", "f1", "424b4", "prospectus"]:
+            return await self._async_download_prospectus(
                 http_client, code, document_type, datasource, checkpoint, on_progress
             )
         elif doc_type_lower in ["6k", "8k"]:
@@ -509,7 +510,7 @@ class MStockAdapter(BaseStockAdapter):
             logger.debug(f"FPI check failed for {code}: {e}, defaulting to 10-Q")
         return "10-Q"
 
-    def _download_s1(
+    def _download_prospectus(
         self,
         code: str,
         document_type: str,
@@ -517,9 +518,47 @@ class MStockAdapter(BaseStockAdapter):
         checkpoint: Optional[Dict[str, Any]],
         on_progress: Optional[Callable],
     ) -> DownloadResult:
-        """下载S-1招股说明书"""
-        form_type = "S-1" if document_type.lower() == "s1" else "S-1/A"
-        return self._download_form(code, form_type, None, checkpoint, on_progress)
+        """下载美股招股说明书
+
+        搜索策略（级联）：
+        1. 用户明确指定 form type → 直接用
+        2. prospectus/s1/s1a → S-1 → F-1 → 424B4 依次尝试
+        """
+        doc_lower = document_type.lower()
+
+        # 用户明确指定 form type
+        form_map = {
+            "s1": "S-1",
+            "s1a": "S-1/A",
+            "f1": "F-1",
+            "424b4": "424B4",
+        }
+        if doc_lower in form_map:
+            return self._download_form(
+                code, form_map[doc_lower], None, checkpoint, on_progress
+            )
+
+        # prospectus: 级联搜索 S-1 → F-1 → 424B4
+        ticker = code.upper()
+        for form in ["S-1", "F-1", "424B4"]:
+            try:
+                filings = self._search_filings(ticker, form, None, size=1)
+                if filings:
+                    logger.info(
+                        f"找到 {ticker} 的 {form} 招股书"
+                    )
+                    return self._download_form(
+                        code, form, None, checkpoint, on_progress
+                    )
+            except Exception as e:
+                logger.debug(f"搜索 {ticker} {form} 失败: {e}")
+                continue
+
+        return DownloadResult(
+            success=False,
+            error_code="NO_FILINGS_FOUND",
+            error_message=f"未找到 {ticker} 的招股书（已尝试 S-1, F-1, 424B4）",
+        )
 
     def _download_6k(
         self,
@@ -832,7 +871,7 @@ class MStockAdapter(BaseStockAdapter):
         form_type = self.get_quarterly_form_type(code)
         return await self._async_download_form(http_client, code, form_type, year, checkpoint, on_progress)
 
-    async def _async_download_s1(
+    async def _async_download_prospectus(
         self,
         http_client: AsyncHTTPClient,
         code: str,
@@ -841,9 +880,11 @@ class MStockAdapter(BaseStockAdapter):
         checkpoint: Optional[Dict[str, Any]],
         on_progress: Optional[Callable],
     ) -> DownloadResult:
-        """异步下载S-1招股说明书"""
-        form_type = "S-1" if document_type.lower() == "s1" else "S-1/A"
-        return await self._async_download_form(http_client, code, form_type, None, checkpoint, on_progress)
+        """异步下载美股招股说明书（同步包装）"""
+        return await asyncio.to_thread(
+            self._download_prospectus,
+            code, document_type, datasource, checkpoint, on_progress
+        )
 
     async def _download_filing_async(
         self,

--- a/unified_downloader/cli.py
+++ b/unified_downloader/cli.py
@@ -220,7 +220,7 @@ def download_group():
     "--type",
     "-t",
     type=click.Choice(
-        ["annual_report", "interim_report", "quarterly", "q1_report", "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "6k", "8k", "20f"],
+        ["annual_report", "interim_report", "quarterly", "q1_report", "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "f1", "424b4", "6k", "8k", "20f"],
         case_sensitive=False,
     ),
     default="annual_report",
@@ -387,7 +387,7 @@ def search_group():
     "--type",
     "-t",
     type=click.Choice(
-        ["annual_report", "interim_report", "quarterly", "q1_report", "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "6k", "8k", "20f"],
+        ["annual_report", "interim_report", "quarterly", "q1_report", "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "f1", "424b4", "6k", "8k", "20f"],
         case_sensitive=False,
     ),
     default="annual_report",
@@ -456,7 +456,7 @@ def search_list(cli_ctx, code, year, type, market, limit):
     "--type",
     "-t",
     type=click.Choice(
-        ["annual_report", "interim_report", "quarterly", "q1_report", "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "6k", "8k", "20f"],
+        ["annual_report", "interim_report", "quarterly", "q1_report", "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "f1", "424b4", "6k", "8k", "20f"],
         case_sensitive=False,
     ),
     default="annual_report",

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -420,6 +420,8 @@ class UnifiedDownloader:
             "8_k": "8K",
             "s1": "S1",
             "s1a": "S1A",
+            "f1": "F1",
+            "424b4": "424B4",
             "prospectus": "S1",
         }
         return labels.get(normalized, document_type.replace("-", "").upper())

--- a/unified_downloader/models/enums.py
+++ b/unified_downloader/models/enums.py
@@ -25,6 +25,8 @@ class DocumentType(str, Enum):
     TEN_Q = "10q"  # 美股10-Q季报
     S1 = "s1"  # 美股S-1招股书
     S1A = "s1a"  # 美股S-1A修正
+    F1 = "f1"  # 美股F-1外国公司招股书
+    F424B4 = "424b4"  # 美股424B4最终招股书（定价版）
     SIX_K = "6k"  # 美股外国公司6-K临时报告
     EIGHT_K = "8k"  # 美股8-K重大事件报告
     TWENTY_F = "20f"  # 美股外国公司20-F年报


### PR DESCRIPTION
## Summary

Adds IPO prospectus (招股说明书) download support across all three markets.

### A-shares (全新功能)
- New `CninfoAPI.search_fulltext()` — 巨潮资讯全文检索 API，支持关键词 + 日期范围
- New `AStockAdapter._download_prospectus()` — 自动搜索 → 智能选最佳匹配 → 下载 PDF
- `AStockAdapter.search()` 新增 prospectus 支持，含年份过滤

### US stocks (增强)
- `_download_s1` → `_download_prospectus`：级联搜索 S-1 → F-1 → 424B4
- 新增 `DocumentType.F1` / `DocumentType.F424B4` 枚举
- CLI type choices 新增 f1 / 424b4

### HK stocks (增强)
- 多檔案检测：file_info 含"多檔案"时返回友好错误 + 披露易链接
- 老股票提示优化：>10年上市股票给出明确说明

## Verification

| 市场 | 股票 | 结果 | 大小 |
|------|------|:--:|------|
| A股 | 600519 茅台 | ✅ | 355KB |
| A股 | 002415 海康 | ✅ | 3.5MB |
| A股 | 300760 迈瑞 | ✅ | 31MB |
| A股 | 000001 平安 | ✅ | 18MB |
| 港股 | 09988 阿里 | ✅ | 8MB |
| 港股 | 01024 快手 | ✅ | 20MB |
| 美股 | BABA | ✅ | 4.9MB F-1 |

## Regression
- A股年报 (600519/000001) ✅
- 港股年报 (00700) ✅