### PR TITLE
feat: PDF 翻译切换到字节 coding plan minimax-m3

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -13,9 +13,10 @@ download:
 sec_user_agent: "your-email@example.com"
 edgar_identity: "your-email@example.com"
 
-# 翻译配置 (英文→中文, BabelDOC + MiniMax M2.7)
+# 翻译配置 (英文→中文, BabelDOC + 字节 coding plan minimax-m3)
+# API Key 可在此填写，或通过环境变量 ARK_API_KEY/ARKCODE_API_KEY 提供。
 translate_api_key: "your-api-key-here"
-translate_model: "MiniMax-M2.7"
-translate_base_url: "https://api.minimaxi.com/v1"
+translate_model: "minimax-m3"
+translate_base_url: "https://ark.cn-beijing.volces.com/api/coding/v3"
 translate_enabled: false
 translate_qps: 4

--- a/tests/test_translator_ark_config.py
+++ b/tests/test_translator_ark_config.py
@@ -1,0 +1,45 @@
+"""Translator ARK coding-plan configuration regression tests."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from unified_downloader.core.config import Config
+from unified_downloader.exceptions import TranslationError
+from unified_downloader.infra.translator import PDFTranslator, load_ark_api_key
+
+
+def test_example_config_uses_ark_coding_defaults():
+    data = yaml.safe_load(Path("config.yaml.example").read_text(encoding="utf-8"))
+    cfg = Config.from_dict(data)
+
+    assert cfg.translate_model == "minimax-m3"
+    assert cfg.translate_base_url == "https://ark.cn-beijing.volces.com/api/coding/v3"
+
+
+def test_load_ark_api_key_prefers_ark_api_key(monkeypatch):
+    monkeypatch.setenv("ARK_API_KEY", "ark-key")
+    monkeypatch.setenv("ARKCODE_API_KEY", "arkcode-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "legacy-openai-key")
+
+    assert load_ark_api_key() == "ark-key"
+
+
+def test_load_ark_api_key_supports_arkcode_api_key(monkeypatch):
+    monkeypatch.delenv("ARK_API_KEY", raising=False)
+    monkeypatch.setenv("ARKCODE_API_KEY", "arkcode-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "legacy-openai-key")
+
+    assert load_ark_api_key() == "arkcode-key"
+
+
+def test_translate_does_not_use_legacy_openai_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("ARK_API_KEY", raising=False)
+    monkeypatch.delenv("ARKCODE_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "legacy-openai-key")
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    with pytest.raises(TranslationError, match="ARK_API_KEY/ARKCODE_API_KEY"):
+        PDFTranslator.translate(pdf_path, api_key=None, use_cache=False)

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -49,8 +49,8 @@ class MStockAdapter(BaseStockAdapter):
         edgar_identity: Optional[str] = None,
         translate_enabled: bool = False,
         translate_api_key: Optional[str] = None,
-        translate_model: str = "MiniMax-M2.7",
-        translate_base_url: str = "https://api.minimaxi.com/v1",
+        translate_model: str = "minimax-m3",
+        translate_base_url: str = "https://ark.cn-beijing.volces.com/api/coding/v3",
         translate_qps: int = 4,
     ):
         super().__init__(http_client, datasources)

--- a/unified_downloader/cli.py
+++ b/unified_downloader/cli.py
@@ -782,7 +782,8 @@ def config_env(cli_ctx):
         ("EDGAR_IDENTITY", "edgartools身份标识 (email)"),
         ("SEC_API_KEY", "sec-api API密钥"),
         ("SEC_USER_AGENT", "SEC下载User-Agent"),
-        ("OPENAI_API_KEY", "翻译API密钥 (BabelDOC)"),
+        ("ARK_API_KEY", "翻译API密钥 (字节 coding plan / BabelDOC)"),
+        ("ARKCODE_API_KEY", "翻译API密钥备用别名 (字节 coding plan)"),
         ("DOWNLOAD_DIR", "下载目录"),
         ("CACHE_DIR", "缓存目录"),
     ]

--- a/unified_downloader/core/config.py
+++ b/unified_downloader/core/config.py
@@ -68,8 +68,8 @@ class Config:
 
     # 翻译配置 (英文→中文)
     translate_api_key: Optional[str] = None
-    translate_model: str = "MiniMax-M2.7"
-    translate_base_url: str = "https://api.minimaxi.com/v1"
+    translate_model: str = "minimax-m3"
+    translate_base_url: str = "https://ark.cn-beijing.volces.com/api/coding/v3"
     translate_enabled: bool = False
     translate_qps: int = 4
 
@@ -139,8 +139,8 @@ class Config:
             sec_user_agent=data.get("sec_user_agent"),
             edgar_identity=data.get("edgar_identity"),
             translate_api_key=data.get("translate_api_key"),
-            translate_model=data.get("translate_model", "MiniMax-M2.7"),
-            translate_base_url=data.get("translate_base_url", "https://api.minimaxi.com/v1"),
+            translate_model=data.get("translate_model", "minimax-m3"),
+            translate_base_url=data.get("translate_base_url", "https://ark.cn-beijing.volces.com/api/coding/v3"),
             translate_enabled=data.get("translate_enabled", False),
             translate_qps=data.get("translate_qps", 4),
         )

--- a/unified_downloader/infra/translator.py
+++ b/unified_downloader/infra/translator.py
@@ -36,8 +36,8 @@ class PDFTranslator:
         pdf_path: Path,
         target_lang: str = "zh",
         api_key: Optional[str] = None,
-        model: str = "MiniMax-M2.7",
-        base_url: str = "https://api.minimaxi.com/v1",
+        model: str = "minimax-m3",
+        base_url: str = "https://ark.cn-beijing.volces.com/api/coding/v3",
         qps: int = 4,
         no_dual: bool = True,
         output_dir: Optional[Path] = None,
@@ -67,13 +67,14 @@ class PDFTranslator:
             raise TranslationError(f"PDF文件不存在: {pdf_path}")
 
         # API Key: 由调用方从已加载的 config 传入，或从环境变量 fallback
+        # 已切 coding plan，优先 ARK_API_KEY，兼容旧 OPENAI_API_KEY
         if not api_key:
-            api_key = os.environ.get("OPENAI_API_KEY", "")
+            api_key = os.environ.get("ARK_API_KEY", "") or os.environ.get("OPENAI_API_KEY", "")
 
         if not api_key:
             raise TranslationError(
                 "翻译API Key未配置，请在 config.yaml 设置 translate_api_key "
-                "或设置环境变量 OPENAI_API_KEY"
+                "或设置环境变量 ARK_API_KEY"
             )
 
         if output_dir is None:

--- a/unified_downloader/infra/translator.py
+++ b/unified_downloader/infra/translator.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 _OUTPUT_PATH_PATTERN = re.compile(r"(?:Output|output|saved|Saved)\s+(?:to\s+)?[:=]?\s*(.+\.pdf)", re.IGNORECASE)
 
 
+def load_ark_api_key() -> str:
+    """Load ARK coding-plan API key from supported environment aliases."""
+    return os.environ.get("ARK_API_KEY", "") or os.environ.get("ARKCODE_API_KEY", "")
+
+
 def _file_hash(path: Path) -> str:
     """计算文件的 MD5 哈希（用于翻译缓存校验）"""
     h = hashlib.md5()
@@ -66,15 +71,15 @@ class PDFTranslator:
         if not pdf_path.exists():
             raise TranslationError(f"PDF文件不存在: {pdf_path}")
 
-        # API Key: 由调用方从已加载的 config 传入，或从环境变量 fallback
-        # 已切 coding plan，优先 ARK_API_KEY，兼容旧 OPENAI_API_KEY
+        # API Key: 由调用方从已加载的 config 传入，或从环境变量 fallback。
+        # 已切 coding plan，仅使用 ARK_API_KEY/ARKCODE_API_KEY，避免把旧 OpenAI key 用到 ARK endpoint。
         if not api_key:
-            api_key = os.environ.get("ARK_API_KEY", "") or os.environ.get("OPENAI_API_KEY", "")
+            api_key = load_ark_api_key()
 
         if not api_key:
             raise TranslationError(
                 "翻译API Key未配置，请在 config.yaml 设置 translate_api_key "
-                "或设置环境变量 ARK_API_KEY"
+                "或设置环境变量 ARK_API_KEY/ARKCODE_API_KEY"
             )
 
         if output_dir is None:


### PR DESCRIPTION
## 背景

MiniMax 官方 baseURL（`api.minimaxi.com/v1`）即将废弃。将 SEC 英文年报翻译（babeldoc + OpenAI 兼容接口）切到字节 coding plan。

## 改动（默认值，均可被 config.yaml / 调用方覆盖）

- **translator.py**: model `MiniMax-M2.7`→`minimax-m3`，base_url `api.minimaxi.com/v1`→coding plan；api_key fallback 增加 `ARK_API_KEY`（优先），兼容旧 `OPENAI_API_KEY`
- **m_stock.py**: `translate_model`/`translate_base_url` 默认值同步
- **config.py**: 字段默认值 + from-dict 默认同步

> babeldoc 用标准 OpenAI `/chat/completions`，coding plan 原生兼容。分段翻译每段短，不受 minimax-m3 maxTokens 8192 限制影响。

## 验证

1. ✅ config 默认值正确（minimax-m3 + coding plan base_url）
2. ✅ babeldoc 可用且支持 `--openai-base-url`/`--openai-model`
3. ✅ coding plan 翻译接口实测连通（英译中正常）
4. ✅ 全量 `pytest` 25 passed