### PR TITLE
fix(m_stock): skip image embed for prospectus forms (S-1/F-1/424B4)

### DIFF
--- a/tests/test_m_stock_skip_embed_prospectus.py
+++ b/tests/test_m_stock_skip_embed_prospectus.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for MStockAdapter prospectus skip-image-embed behavior.
+
+Regression: PR #38 issue — 招股书 S-1 招股书 embed base64 后 8.5M → 51M，
+触发 IMA 后端不索引 body content。
+修复: 招股书 (S-1/F-1/424B4 等) 跳过 _embed_images_as_base64。
+
+这些测试只测"招股书跳过 embed"逻辑，不下载真实文件。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import MStockAdapter  # noqa: E402
+
+
+class TestProspectusFormsConstant:
+    """招股书 form 常量必须包含 S-1/F-1/424B4 全家族"""
+
+    def test_prospectus_forms_includes_s1(self):
+        assert "S-1" in MStockAdapter._PROSPECTUS_FORMS
+        assert "S-1/A" in MStockAdapter._PROSPECTUS_FORMS
+
+    def test_prospectus_forms_includes_f1(self):
+        assert "F-1" in MStockAdapter._PROSPECTUS_FORMS
+        assert "F-1/A" in MStockAdapter._PROSPECTUS_FORMS
+
+    def test_prospectus_forms_includes_424b(self):
+        # 424B 系列是已定价的 prospectus
+        assert "424B4" in MStockAdapter._PROSPECTUS_FORMS
+        assert "424B3" in MStockAdapter._PROSPECTUS_FORMS
+        assert "424B5" in MStockAdapter._PROSPECTUS_FORMS
+
+    def test_prospectus_forms_excludes_annual_reports(self):
+        # 10-K/10-Q/20-F/8-K/6-K 不应被当招股书（这些仍走 embed）
+        for f in ("10-K", "10-Q", "20-F", "8-K", "6-K"):
+            assert f not in MStockAdapter._PROSPECTUS_FORMS, (
+                f"{f} 不应被视为招股书 (应是季报/年报/重大事件)"
+            )
+
+    def test_prospectus_forms_is_frozenset(self):
+        # frozenset 保证不可变
+        assert isinstance(MStockAdapter._PROSPECTUS_FORMS, frozenset)
+
+
+class TestProspectusSkipsEmbed:
+    """_download_filing 流程中，招股书 form 不应调 _embed_images_as_base64"""
+
+    @pytest.fixture
+    def adapter(self):
+        """构造一个 MStockAdapter mock 桩 (只测逻辑，不下载文件)"""
+        http_client = MagicMock()
+        datasources: list = []
+        return MStockAdapter(http_client, datasources)
+
+    @pytest.mark.parametrize("form_type", ["S-1", "S-1/A", "F-1", "F-1/A", "424B4", "424B3", "424B5"])
+    def test_prospectus_form_skips_embed(self, adapter, form_type, tmp_path):
+        """所有招股书 form 都不调 _embed_images_as_base64"""
+        # 准备: 一个 HTML 文件 + filing dict + form_type
+        html_path = tmp_path / f"test_{form_type.replace('/', '_')}.html"
+        html_path.write_text("<html><body>Test prospectus</body></html>")
+
+        filing = {
+            "linkToTxt": f"https://www.sec.gov/test/{form_type}.htm",
+            "filedAt": "2026-07-21",
+        }
+
+        with patch.object(adapter, "_http_client") as mock_http, \
+             patch.object(adapter, "_embed_images_as_base64") as mock_embed, \
+             patch.object(adapter, "_rate_limiter"):
+
+            mock_http.download_file.return_value = {
+                "file_path": str(html_path),
+                "file_size": html_path.stat().st_size,
+            }
+
+            result = adapter._download_filing(
+                filing=filing,
+                ticker="TEST",
+                form_type=form_type,
+                year=2026,
+                on_progress=None,
+                checkpoint=None,
+            )
+
+            # 关键断言: 招股书不该调 embed
+            assert mock_embed.call_count == 0, (
+                f"招股书 {form_type} 不应触发 _embed_images_as_base64 (实际调了 {mock_embed.call_count} 次)"
+            )
+
+    @pytest.mark.parametrize("form_type", ["10-K", "10-Q", "20-F", "6-K", "8-K"])
+    def test_non_prospectus_form_does_embed(self, adapter, form_type, tmp_path):
+        """非招股书 form (10-K/10-Q/20-F/6-K/8-K) 仍走 embed (回归保护)"""
+        html_path = tmp_path / f"test_{form_type.replace('-', '_')}.html"
+        html_path.write_text("<html><body>Test annual</body></html>")
+
+        filing = {
+            "linkToTxt": f"https://www.sec.gov/test/{form_type}.htm",
+            "filedAt": "2026-07-21",
+        }
+
+        with patch.object(adapter, "_http_client") as mock_http, \
+             patch.object(adapter, "_embed_images_as_base64") as mock_embed, \
+             patch.object(adapter, "_rate_limiter"):
+
+            mock_http.download_file.return_value = {
+                "file_path": str(html_path),
+                "file_size": html_path.stat().st_size,
+            }
+
+            # 6-K 还要 mock _merge_6k_exhibits (避免走真实下载)
+            with patch.object(adapter, "_merge_6k_exhibits") as mock_merge:
+                mock_merge.return_value = html_path
+                result = adapter._download_filing(
+                    filing=filing,
+                    ticker="TEST",
+                    form_type=form_type,
+                    year=2026,
+                    on_progress=None,
+                    checkpoint=None,
+                )
+
+            # 关键断言: 非招股书仍调 embed
+            assert mock_embed.call_count == 1, (
+                f"非招股书 {form_type} 应触发 _embed_images_as_base64 1 次 (实际 {mock_embed.call_count} 次)"
+            )

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -873,12 +873,22 @@ class MStockAdapter(BaseStockAdapter):
                             logger.warning(f"6-K exhibit merge failed, using cover only: {e}")
 
                 # 嵌入所有相对路径图片为base64 data URI，保证单文件HTML自带图片，上传IMA不会图挂
+                # 2026-07-21 fix: 招股书 (S-1/F-1/424B4 等) 跳过 embed —— 招股书图片
+                # 嵌 base64 后 8.5M → 51M，触发 IMA 后端不索引 body content。
+                # 招股书图片装饰性多、重要性低，跳过 embed 反而可用。
+                # 6-K/10-K/10-Q 仍保留 embed (图片一般是 logo/财务图，实用价值高)
                 if downloaded_path.suffix.lower() in (".html", ".htm"):
-                    try:
-                        self._embed_images_as_base64(downloaded_path, link, headers)
-                        logger.debug(f"Embedded relative images into {downloaded_path.name}")
-                    except Exception as e:
-                        logger.warning(f"图片嵌入处理失败，保留原始HTML: {e}")
+                    if form_type in self._PROSPECTUS_FORMS:
+                        logger.info(
+                            f"[m_stock] 招股书 {form_type} 跳过 embed base64: {downloaded_path.name} "
+                            f"原因=避免文件膨胀触发 IMA 不索引"
+                        )
+                    else:
+                        try:
+                            self._embed_images_as_base64(downloaded_path, link, headers)
+                            logger.debug(f"Embedded relative images into {downloaded_path.name}")
+                        except Exception as e:
+                            logger.warning(f"图片嵌入处理失败，保留原始HTML: {e}")
 
                 converted_to_pdf = False
                 if (
@@ -1159,6 +1169,13 @@ class MStockAdapter(BaseStockAdapter):
         "s1": "S-1",
         "s1a": "S-1/A",
     }
+
+    # 招股书 form 类型集合（不嵌 base64 图片，避免 IMA 不索引大文件）
+    # 招股书 (S-1/F-1/424B4) 通常含 30+ 张 logo/财务图表装饰图，
+    # 嵌 base64 后文件膨胀 6x+ (8.5M → 51M)，
+    # 触发 IMA 后端不索引 body content（仅 record 元数据）
+    # 招股书图片重要性低，跳过 embed 直接传主 HTML 即可
+    _PROSPECTUS_FORMS = frozenset({"S-1", "S-1/A", "F-1", "F-1/A", "424B4", "424B3", "424B5"})
 
     @classmethod
     def _normalize_form_type(cls, form_type: str) -> str:


### PR DESCRIPTION
## Fixes #38

## 问题

招股书 S-1 embed base64 后 8.5M → 51M，触发 IMA 后端不索引 body content（仅 record 元数据），招股书 KB 实际不可用。

## 根因

`unified_downloader/adapters/m_stock.py` `_embed_images_as_base64()` (line 697) 对所有 HTML 都跑，**招股书图片装饰性多、嵌 base64 后 6x 膨胀**（8.5M → 51M，44.6s embed）。

历史背景：commit `38b9f16`（"美股不再强制转PDF，直接上传内嵌图片的HTML到IMA"）是**有意设计**——为了"上传 IMA 不会图挂"。但 51MB 副作用是 IMA 不索引。

## 修复

**最小改动**：
- 新增 `_PROSPECTUS_FORMS = {S-1, S-1/A, F-1, F-1/A, 424B4, 424B3, 424B5}` frozenset 常量
- `_download_filing()` 在招股书 form 跳过 `_embed_images_as_base64`
- 6-K/10-K/10-Q/20-F/8-K 仍走 embed（图片一般是 logo/财务图，实用价值高）

## e2e 验证（JMKE S-1 招股书）

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| 文件大小 | 51M | 8.5M |
| embed 耗时 | 44.6s | 0s (skip) |
| IMA search `Jersey` 30s | ❌ 0 hits | ✅ 1 hit |
| IMA search 1.5h | ❌ 仍 0 hits | (不适用) |

## 测试

**17/17 新增**（`tests/test_m_stock_skip_embed_prospectus.py`）：
- 5 `_PROSPECTUS_FORMS` 常量测试（必须含 S-1/F-1/424B4；不含 10-K/10-Q/20-F/6-K/8-K；frozenset 类型）
- 7 招股书 form parametrize 验证 `_embed_images_as_base64` 不被调
- 5 非招股书 form parametrize 验证 `_embed_images_as_base64` 仍被调（回归保护）

**全量 45 pass / 1 pre-existing fail**（与本 PR 无关，main 上也 fail —— `test_bulk_download_us_quarterly` assert `--pdf` 缺失）。

## 关联

- **Fixes** #38
- **Related**: xueqiu-analyzer-skill PR #22（修 `type=20 text/html`）—— 本 PR 是其上游修复
- **2026-07-21 实际方案**：从 SEC EDGAR 直下载 8.5M 主文件 → 立即 IMA 索引成功。**本 PR 让 unified-downloader 走相同的路径**

## 验收

- [x] 修后 JMKE S-1 文件 < 15MB（实际 8.5M）
- [x] `upload_to_ima` 后 30s 内 `Jersey` search 命中
- [x] 6-K/10-K/10-Q/20-F/8-K 行为不变
- [x] 不破坏现有 6-K 合并逻辑

## 风险

- 招股书图片不显示（跳过 embed 后图片是相对路径，上传 IMA 后图会挂）
- 缓解：招股书图片主要是 logo/装饰图，不是财务图/数字图
- 缓解：招股书主要是 KB 索引用，IMA 端用户可以点链接回 SEC EDGAR 看原版（含图）
