### PR TITLE
feat(m_stock): integrate adr_map for use_sec_20f_only dispatch (W36)

### DIFF
--- a/scripts/bulk_download.py
+++ b/scripts/bulk_download.py
@@ -50,7 +50,6 @@ log = logging.getLogger("bulk")
 # ── 路径常量 ──
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
-ADR_MAP_FILE = PROJECT_ROOT / "config" / "adr_map.json"
 DEFAULT_IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
 IMA_SYNC_SCRIPT = Path(os.environ.get("IMA_SYNC_SCRIPT_PATH", DEFAULT_IMA_SYNC_SCRIPT))
 TZ_CN = timezone(timedelta(hours=8))
@@ -71,33 +70,14 @@ def run(cmd, timeout=120):
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd=str(PROJECT_ROOT))
     return r.returncode, r.stdout.strip(), r.stderr.strip()
 
-def load_adr_map():
-    return json.loads(ADR_MAP_FILE.read_text()) if ADR_MAP_FILE.exists() else {}
-
-def _us_key_variants(code):
-    """Return normalized lookup keys for US tickers with/without .US suffix."""
-    cu = code.upper()
-    base = cu[:-3] if cu.endswith(".US") else cu
-    return (cu, base, f"{base}.US")
-
-def _lookup_us_map(mapping, code):
-    for key in _us_key_variants(code):
-        if key in mapping:
-            return key, mapping[key]
-    return None, None
-
-def resolve_target(code, market, adr_map):
-    mkt = market.upper()
-    cu = code.upper()
-    if mkt == "US":
-        key, info = _lookup_us_map(adr_map.get("use_hk_source", {}), cu)
-        if info:
-            return info["hk_code"], "HK", True, False
-        key, info = _lookup_us_map(adr_map.get("use_sec_20f_only", {}), cu)
-        if info:
-            base = cu[:-3] if cu.endswith(".US") else cu
-            return base, "US", False, True
-    return code, mkt, False, False
+# W36: 复用 unified_downloader.utils.adr_map, 避免跟 m_stock 重复实现.
+# 老代码 (load_adr_map / _us_key_variants / _lookup_us_map / resolve_target)
+# 在 bulk_download 跟 m_stock 各自一份, 容易 drift.
+from unified_downloader.utils.adr_map import (
+    load_adr_map,        # noqa: F401  保留脚本级调用方
+    resolve_target,
+    is_adr_skipped,
+)
 
 def quarterly_search_market(is_adr_hk, is_20f, mkt_key):
     if is_adr_hk:

--- a/tests/test_adr_map.py
+++ b/tests/test_adr_map.py
@@ -1,0 +1,206 @@
+"""Unit tests for unified_downloader.utils.adr_map.
+
+Covers:
+  * load_adr_map returns the on-disk JSON.
+  * _us_key_variants normalizes HESAY/HESAY.US/hesay correctly.
+  * resolve_target dispatches:
+      - use_hk_source  → hk_code + HK + is_adr_hk=True
+      - use_sec_20f_only → base ticker + US + is_20f_only=True
+      - default US      → unchanged + both flags False
+      - non-US markets  → identity (no rewriting)
+  * is_adr_skipped: dedup_skip_us list membership with/without .US suffix.
+
+The cases track the current adr_map.json shape (4 use_hk_source + 6
+use_sec_20f_only + 3 dedup_skip_us). If adr_map.json grows, add the
+new tickers here so regressions surface immediately.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from unified_downloader.utils.adr_map import (
+    ADR_MAP_FILE,
+    _us_key_variants,
+    is_adr_skipped,
+    load_adr_map,
+    resolve_target,
+)
+
+
+# A representative adr_map shape — keep this in sync with the real file.
+FAKE_ADR_MAP = {
+    "use_hk_source": {
+        "TCEHY.US": {"hk_code": "0700", "name": "腾讯控股"},
+        "BEKE.US":  {"hk_code": "2423", "name": "贝壳-W"},
+        "HTHT.US":  {"hk_code": "1179", "name": "华住集团-S"},
+        "MNSO.US":  {"hk_code": "9896", "name": "名创优品"},
+    },
+    "use_sec_20f_only": {
+        "HESAY.US": "爱马仕(ADR)",
+        "NTDOY.US": "任天堂(ADR)",
+        "NVO.US":   "诺和诺德(ADR)",
+        "ASML.US":  "阿斯麦",
+        "TSM.US":   "台积电",
+        "RACE.US":  "法拉利",
+    },
+    "dedup_skip_us": ["TCEHY.US", "BEKE.US", "HTHT.US"],
+}
+
+
+# ── load_adr_map ──────────────────────────────────────────────────────
+
+
+def test_load_adr_map_returns_real_file():
+    """The real config/adr_map.json must parse without errors."""
+    data = load_adr_map()
+    assert isinstance(data, dict)
+    # 三个 key 必须存在 (跟 plan 7-30 W35 issue 文档一致)
+    assert "use_hk_source" in data
+    assert "use_sec_20f_only" in data
+    assert "dedup_skip_us" in data
+
+
+def test_load_adr_map_missing_file_returns_empty():
+    """A missing adr_map.json should not raise — callers rely on this."""
+    with patch.object(Path, "exists", return_value=False):
+        data = load_adr_map()
+    assert data == {}
+
+
+def test_adr_map_file_path():
+    """ADR_MAP_FILE should point at config/adr_map.json under project root."""
+    assert ADR_MAP_FILE.name == "adr_map.json"
+    assert ADR_MAP_FILE.parent.name == "config"
+
+
+# ── _us_key_variants ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("HESAY", ("HESAY", "HESAY", "HESAY.US")),
+        ("HESAY.US", ("HESAY.US", "HESAY", "HESAY.US")),
+        ("hesay", ("HESAY", "HESAY", "HESAY.US")),
+        ("tsla", ("TSLA", "TSLA", "TSLA.US")),
+    ],
+)
+def test_us_key_variants_normalizes(code, expected):
+    assert _us_key_variants(code) == expected
+
+
+# ── resolve_target: use_hk_source ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code,expected_code,expected_mkt,expected_hk,expected_20f",
+    [
+        ("TCEHY",     "0700", "HK", True,  False),
+        ("TCEHY.US",  "0700", "HK", True,  False),
+        ("BEKE.US",   "2423", "HK", True,  False),
+        ("HTHT",      "1179", "HK", True,  False),
+        ("MNSO.US",   "9896", "HK", True,  False),
+    ],
+)
+def test_resolve_target_use_hk_source(code, expected_code, expected_mkt, expected_hk, expected_20f):
+    dl_code, dl_mkt, is_hk, is_20f = resolve_target(code, "US", FAKE_ADR_MAP)
+    assert (dl_code, dl_mkt, is_hk, is_20f) == (expected_code, expected_mkt, expected_hk, expected_20f)
+
+
+# ── resolve_target: use_sec_20f_only ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code,expected_code,expected_mkt,expected_20f",
+    [
+        ("HESAY",     "HESAY", "US", True),
+        ("HESAY.US",  "HESAY", "US", True),  # .US 也要正确剥离
+        ("NTDOY.US",  "NTDOY", "US", True),
+        ("NVO",       "NVO",   "US", True),
+        ("ASML.US",   "ASML",  "US", True),
+        ("TSM",       "TSM",   "US", True),
+        ("RACE.US",   "RACE",  "US", True),
+    ],
+)
+def test_resolve_target_use_sec_20f_only(code, expected_code, expected_mkt, expected_20f):
+    _, dl_mkt, is_hk, is_20f = resolve_target(code, "US", FAKE_ADR_MAP)
+    assert is_hk is False
+    assert (dl_mkt, is_20f) == (expected_mkt, expected_20f)
+    assert dl_mkt == "US"
+
+
+# ── resolve_target: default US (13 SUCCESS records) ──────────────────
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "AAPL", "MSFT", "TSLA", "NVDA", "GOOGL", "META", "AMZN",
+        "NFLX",  "AMD",  "INTC", "ORCL", "CRM",  "ADBE",
+    ],
+)
+def test_resolve_target_default_us_passthrough(code):
+    """13 US 本土 ticker (跟 W34 SUCCESS records 一致) 必须完全 passthrough.
+
+    这是 W36 PR #48 关键不 regress 约束. m_stock 走 default 10-K/10-Q 路径,
+    不被 adr_map 改写.
+    """
+    dl_code, dl_mkt, is_hk, is_20f = resolve_target(code, "US", FAKE_ADR_MAP)
+    assert (dl_code, dl_mkt, is_hk, is_20f) == (code, "US", False, False)
+
+
+# ── resolve_target: non-US markets ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code,market,expected_code,expected_mkt",
+    [
+        ("600519", "CN", "600519", "CN"),
+        ("000933", "CN", "000933", "CN"),
+        ("00700",  "HK", "00700",  "HK"),
+        ("09988",  "HK", "09988",  "HK"),
+    ],
+)
+def test_resolve_target_non_us_identity(code, market, expected_code, expected_mkt):
+    """非 US market 必须 identity 透传, 任何 adr_map 都不改写."""
+    dl_code, dl_mkt, is_hk, is_20f = resolve_target(code, market, FAKE_ADR_MAP)
+    assert (dl_code, dl_mkt, is_hk, is_20f) == (expected_code, expected_mkt, False, False)
+
+
+# ── is_adr_skipped ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("TCEHY",    True),   # dedup_skip_us 命中
+        ("TCEHY.US", True),
+        ("BEKE.US",  True),
+        ("HTHT",     True),
+        ("AAPL",     False),  # 不在 dedup_skip_us
+        ("HESAY",    False),  # 在 use_sec_20f_only 但不在 dedup
+        ("TSLA",     False),
+    ],
+)
+def test_is_adr_skipped(code, expected):
+    assert is_adr_skipped(code, FAKE_ADR_MAP) is expected
+
+
+def test_is_adr_skipped_empty_map():
+    assert is_adr_skipped("TCEHY", {}) is False
+
+
+# ── 集成: 跟真实 adr_map.json 数量级 ──────────────────────────────────
+
+
+def test_real_adr_map_has_expected_categories():
+    """真实 adr_map.json 必须三类都有, 且数量级跟 W35 issue 文档一致."""
+    data = load_adr_map()
+    assert len(data.get("use_hk_source", {})) >= 4
+    assert len(data.get("use_sec_20f_only", {})) >= 6
+    assert len(data.get("dedup_skip_us", [])) >= 3

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -482,8 +482,31 @@ class MStockAdapter(BaseStockAdapter):
         外国私人发行人(FPI)如中概股/ADR，年度用20-F
         美国本土公司用10-K
 
+        W36: edgartools Company() 对 OTC ADR (Hermes / LVMH 等) 抛
+        "Company not found" 之前根本到不了 is_foreign 判断, 所以单靠
+        edgartools FPI check 永远返回 10-K, 然后下载 10-K 又失败.
+        我们不修 edgartools, 而是看 adr_map.use_sec_20f_only: 命中 → 20-F
+        (即便 edgartools 找不到 ticker, 也至少让 m_stock 走对的 form,
+        错误信息变为 "20-F not found" 而不是 "10-K not found", 暴露真因).
+
+        use_hk_source (TCEHY/BEKE/HTHT/MNSO) 不在这里处理 — 这些 ticker
+        根本不该走 m_stock, 应在上层 dispatch 改走 h_stock. 这里是
+        SEC form type 决策, 不是 market 决策.
+
         作为 USFormResolver 协议成员被 UnifiedDownloader 跨模块调用。
         """
+        # W36: adr_map.use_sec_20f_only 优先, 因为 edgartools 对
+        # 不在 SEC EDGAR 的 OTC ADR 抛 "Company not found" 之前到不了
+        # is_foreign 判断. 即便 adr_map 命中, 后面 _download_form 仍
+        # 会失败, 但失败信息从 "primary=10k not found" 变成
+        # "primary=20f not found", 正确暴露真因 (不是 SEC 源).
+        from unified_downloader.utils.adr_map import load_adr_map, resolve_target
+        adr_map = load_adr_map()
+        _, _, _, is_20f_only = resolve_target(code, "US", adr_map)
+        if is_20f_only:
+            logger.info(f"{code} is in adr_map.use_sec_20f_only, using 20-F for annual report")
+            return "20-F"
+
         try:
             if self._init_edgar():
                 from edgar import Company
@@ -514,8 +537,20 @@ class MStockAdapter(BaseStockAdapter):
         外国私人发行人(Foreign Private Issuer)如中概股，季度用6-K
         美国本土公司使用10-Q
 
+        W36: 同 annual, adr_map.use_sec_20f_only 优先 → 6-K.
+        use_hk_source 不在这里处理 (跟 get_annual_form_type 同样理由:
+        market dispatch 是上层的事, 这里是 SEC form type 决策).
+
         作为 USFormResolver 协议成员被 UnifiedDownloader 跨模块调用。
         """
+        # W36: 跟 annual 同步, adr_map.use_sec_20f_only 优先.
+        from unified_downloader.utils.adr_map import load_adr_map, resolve_target
+        adr_map = load_adr_map()
+        _, _, _, is_20f_only = resolve_target(code, "US", adr_map)
+        if is_20f_only:
+            logger.info(f"{code} is in adr_map.use_sec_20f_only, using 6-K for quarterly report")
+            return "6-K"
+
         try:
             if self._init_edgar():
                 from edgar import Company

--- a/unified_downloader/utils/__init__.py
+++ b/unified_downloader/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Unified downloader utility modules.
+
+ADR map helpers live in `unified_downloader.utils.adr_map` and are used by
+both the per-stock adapter path (m_stock) and the bulk download script
+(scripts/bulk_download.py).
+"""

--- a/unified_downloader/utils/adr_map.py
+++ b/unified_downloader/utils/adr_map.py
@@ -1,0 +1,129 @@
+"""ADR map loading and lookup helpers.
+
+The single source of truth for ticker-level data source overrides lives in
+``config/adr_map.json``. It declares three routing categories used across
+the project:
+
+* ``use_hk_source`` — ADR that has a primary HK listing (TCEHY/BEKE/HTHT/
+  MNSO). When a US ticker is in this set, m_stock should refuse to call
+  SEC EDGAR and instead route the request to ``h_stock`` using the
+  ``hk_code`` field.
+* ``use_sec_20f_only`` — Foreign Private Issuer (FPI) ADRs that are NOT
+  present in SEC EDGAR (HESAY/NTDOY/NVO/ASML/TSM/RACE). The right SEC
+  form is 20-F (annual) / 6-K (quarterly); m_stock's default
+  ``primary=10k/10q`` lookup will always fail for these tickers because
+  ``edgar.Company(code)`` raises "Company not found" before the FPI
+  check runs.
+* ``dedup_skip_us`` — ADR whose HK source is already covered by another
+  earnings entry (TCEHY/BEKE/HTHT). The bulk_download path silently
+  drops these from the US run to avoid double work.
+
+``scripts/bulk_download.py`` previously inlined ``load_adr_map`` /
+``_us_key_variants`` / ``resolve_target``. The same logic is now exposed
+here so m_stock (single-stock path) and the bulk script can share one
+implementation.
+
+Lookup keys: ``HESAY``, ``HESAY.US`` and ``hesay`` should all resolve to
+the same row. ``_us_key_variants`` generates the three normalizations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Project root: unified_downloader/utils/adr_map.py -> project root
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ADR_MAP_FILE = _PROJECT_ROOT / "config" / "adr_map.json"
+
+
+def load_adr_map(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load adr_map.json from disk.
+
+    Returns an empty mapping (instead of raising) if the file is missing
+    so callers don't have to guard against first-run / fresh-checkout
+    scenarios.
+    """
+    target = path or ADR_MAP_FILE
+    if not target.exists():
+        logger.warning("adr_map.json not found at %s, returning empty map", target)
+        return {}
+    return json.loads(target.read_text(encoding="utf-8"))
+
+
+def _us_key_variants(code: str) -> Tuple[str, str, str]:
+    """Return the (code, base, base.US) lookup variants for a US ticker.
+
+    Adapters historically accept tickers with or without the ``.US``
+    suffix and sometimes normalize to uppercase. Generating all three
+    keeps lookups robust regardless of caller convention.
+    """
+    cu = code.upper().strip()
+    base = cu[:-3] if cu.endswith(".US") else cu
+    return cu, base, f"{base}.US"
+
+
+def _lookup_us_map(mapping: Dict[str, Any], code: str) -> Tuple[Optional[str], Any]:
+    """Return ``(matched_key, value)`` for the first key variant present."""
+    for key in _us_key_variants(code):
+        if key in mapping:
+            return key, mapping[key]
+    return None, None
+
+
+def resolve_target(
+    code: str, market: str, adr_map: Dict[str, Any]
+) -> Tuple[str, str, bool, bool]:
+    """Decide where a US ticker should actually be downloaded from.
+
+    Returns ``(download_code, download_market, is_adr_hk, is_20f_only)``:
+
+    * ``is_adr_hk=True`` — caller should route the request to the HK
+      adapter using ``download_code`` (5-digit numeric).
+    * ``is_20f_only=True`` — caller should use SEC form 20-F (annual) /
+      6-K (quarterly) instead of the default 10-K / 10-Q.
+    * Both flags False — default US path with 10-K / 10-Q.
+
+    For non-US markets the function is the identity: it returns the
+    original code/market and both flags False. This keeps the function
+    safe to call from generic dispatch sites without a market guard.
+    """
+    mkt = market.upper()
+    if mkt != "US":
+        return code, mkt, False, False
+
+    key, info = _lookup_us_map(adr_map.get("use_hk_source", {}), code)
+    if info:
+        # ``info`` is a dict like {"hk_code": "0700", "name": "腾讯控股", ...}
+        hk_code = info.get("hk_code", code)
+        return hk_code, "HK", True, False
+
+    key, info = _lookup_us_map(adr_map.get("use_sec_20f_only", {}), code)
+    if info:
+        base = code.upper()
+        base = base[:-3] if base.endswith(".US") else base
+        return base, "US", False, True
+
+    return code, "US", False, False
+
+
+def is_adr_skipped(code: str, adr_map: Dict[str, Any]) -> bool:
+    """True if the US ticker is listed in ``dedup_skip_us``.
+
+    Bulk download uses this to drop ADRs that are already covered by a
+    separate HK earnings entry (e.g. TCEHY is in HK as 0700.HK, so the
+    US run skips it). m_stock does not currently call this — the per-
+    ticker download is a manual operator action where skipping without
+    an explicit request would be surprising.
+    """
+    # dedup_skip_us is a list (not a dict) in adr_map.json, so we can't
+    # reuse _lookup_us_map which does dict[key] lookups. Inline the
+    # membership test with the same _us_key_variants normalization.
+    for key in _us_key_variants(code):
+        if key in adr_map.get("dedup_skip_us", []):
+            return True
+    return False


### PR DESCRIPTION
## 背景
morning-brief W34/W35 排查发现 HESAY Hermes ADR 走 m_stock 永远 fail:
```
edgartools搜索失败 HESAY 10-K: Company not found: 'HESAY'
fallback_not_tried=20f,8k
```
真因: HESAY 是 OTC ADR 不在 SEC EDGAR → m_stock 写死 primary=10k (line 563 之前)
→ 错误信息 'primary=10k fallback_not_tried=20f,8k' 永远不准

**4 bug issue 文档**: ~/.openclaw/workspace/plans/2026-07-30-unified-downloader-issues.md

## 修复
1. 新加 `unified_downloader/utils/adr_map.py` (~140 行): load_adr_map +
   resolve_target + is_adr_skipped, 跟 bulk_download 之前 inline 实现对齐
2. m_stock `get_annual_form_type` 跟 `get_quarterly_form_type` 优先查
   adr_map.use_sec_20f_only, 命中 → 20-F / 6-K
3. bulk_download.py 删 4 个 inline 函数, 改 import utils (避免 drift)
4. tests/test_adr_map.py 新加 45 case

## 范围
**只做 SEC form type 决策**, 不动 market dispatch:
- use_sec_20f_only (HESAY/NTDOY/NVO/ASML/TSM/RACE 6 个) → 20-F/6-K ✅
- use_hk_source (TCEHY/BEKE/HTHT/MNSO 4 个) → 老行为 (上层 dispatch 改 HK,
  这是 P2 follow-up, 不在本 PR)
- 13 US 本土 (AAPL/MSFT/TSLA 等) → 10-K/10-Q (不变, 跟 W34 SUCCESS 一致)

## 测试
- 45/45 new test_adr_map.py pass
- 90/91 total (1 pre-existing fail 跟 HEAD main 同样, 跟本 PR 无关)
- 0 regress: 13 US 本土 ticker dispatch 完全不变

## 真实行为验证
```
AAPL    : annual=10-K    quarterly=10-Q  (跟 W34 13 SUCCESS 一致)
HESAY   : annual=20-F    quarterly=6-K   (新行为, 错误信息暴露真因)
TCEHY   : annual=10-K    quarterly=10-Q  (use_hk_source, 上层 dispatch 应改 HK)
BEKE    : annual=20-F    quarterly=6-K   (edgartools FPI 命中, 老行为)
```

## 关联
- morning-brief PR #47 (MERGED 6a23a46): W34 verifier 修
- morning-brief 7-30 W35: HESAY 标 SKIPPED + market US→EU
- morning-brief plan: 2026-07-30-w36-unified-downloader-bugs.md
- morning-brief plan: 2026-07-30-unified-downloader-issues.md
- unified-downloader PR #20 (b12bfa3): bulk_download ADR
- unified-downloader PR #32 (4a2ff5e): adr_map config