### PR TITLE
feat(eu_stock): add EU market skeleton + Market.E enum (W36 PR #50a)

### DIFF
--- a/tests/test_eu_stock_skeleton.py
+++ b/tests/test_eu_stock_skeleton.py
@@ -95,3 +95,33 @@ def test_unified_downloader_wires_market_e():
     src = open(UnifiedDownloader.__module__.replace(".", "/") + ".py").read()
     assert "Market.E:" in src, "UnifiedDownloader must dispatch Market.E"
     assert "EuStockAdapter(" in src, "UnifiedDownloader must instantiate EuStockAdapter"
+
+
+def test_detect_market_recognises_eu_tickers():
+    """W36 PR #50a follow-up: _detect_market must identify EU ticker format.
+
+    EU tickers are 1-5 uppercase letters + '.' + 2-3 uppercase letters
+    (e.g. RMS.PA, MC.PA, ASML.AS, RACE.MI, SAP.DE). Without this rule,
+    -m e demo (which passes RMS.PA through _detect_market) raises
+    MarketUnrecognizedError before the EU adapter is even invoked.
+    """
+    import re
+
+    # Read the pattern from the source so the test stays in sync if the
+    # regex is tightened later.
+    from unified_downloader.core.downloader import UnifiedDownloader
+    src = open(UnifiedDownloader.__module__.replace(".", "/") + ".py").read()
+    # Extract the EU regex line.
+    import re as _re
+    m = _re.search(r"r\"(\^\[A-Z\]\{1,5\}\\\.\[A-Z\]\{2,3\}\$)\"", src)
+    assert m, "EU ticker regex must be present in UnifiedDownloader._detect_market"
+    pattern = m.group(1)
+    for code in ["RMS.PA", "MC.PA", "ASML.AS", "RACE.MI", "OR.PA", "SAP.DE", "ENI.MI"]:
+        assert _re.match(pattern, code), f"{code} should match the EU pattern"
+    # Sanity: a malformed EU ticker should NOT match.
+    assert not _re.match(pattern, "RMS.P"), "RMS.P is too short"
+    assert not _re.match(pattern, "RMS.PAAX"), "RMS.PAAX is too long"
+    # And existing CN / HK / US patterns must not collide.
+    assert not _re.match(pattern, "600519"), "CN codes must not match EU"
+    assert not _re.match(pattern, "AAPL"), "US tickers must not match EU"
+    assert not _re.match(pattern, "00700"), "HK codes must not match EU"

--- a/tests/test_eu_stock_skeleton.py
+++ b/tests/test_eu_stock_skeleton.py
@@ -1,0 +1,97 @@
+"""W36 PR #50a: EU adapter skeleton regression tests.
+
+Covers the smallest useful surface of the new EU adapter:
+
+* Market.E enum exists and parses from the string "e".
+* EuStockAdapter inherits BaseStockAdapter and exposes ``market = Market.E``.
+* EuStockAdapter.download / search / get_available_years raise
+  ``NotImplementedError`` with a message that points at PR #50b
+  (so any production caller that reaches the EU path fails loudly).
+* UnifiedDownloader wires ``Market.E`` -> ``EuStockAdapter`` so
+  ``-m e`` doesn't AttributeError in the CLI dispatch.
+
+These tests do NOT exercise real EU data sources — that's PR #50b.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unified_downloader.adapters import EuStockAdapter, BaseStockAdapter
+from unified_downloader.adapters.eu_stock import EuStockAdapter as DirectImport
+from unified_downloader.models.enums import Market
+
+
+# ── Market.E enum ─────────────────────────────────────────────────────
+
+
+def test_market_e_exists():
+    assert Market.E.value == "e"
+
+
+def test_market_e_parses_from_string():
+    """CLI flag `-m e` must resolve to Market.E."""
+    assert Market("e") is Market.E
+
+
+# ── EuStockAdapter identity ───────────────────────────────────────────
+
+
+def test_eu_adapter_inherits_base():
+    assert issubclass(EuStockAdapter, BaseStockAdapter)
+
+
+def test_eu_adapter_market_is_e():
+    assert EuStockAdapter.market is Market.E
+
+
+def test_eu_adapter_direct_import_matches_package_import():
+    """The two import paths must resolve to the same class."""
+    assert EuStockAdapter is DirectImport
+
+
+# ── NotImplementedError surface ──────────────────────────────────────
+
+
+def _make_adapter() -> EuStockAdapter:
+    from unified_downloader.infra.http_client import HTTPClient
+    return EuStockAdapter(http_client=HTTPClient(), datasources=[])
+
+
+def test_eu_download_raises_not_implemented():
+    a = _make_adapter()
+    with pytest.raises(NotImplementedError) as exc:
+        a.download(code="RMS.PA", year=2024, document_type="annual_report")
+    assert "PR #50b" in str(exc.value)
+
+
+def test_eu_search_raises_not_implemented():
+    a = _make_adapter()
+    with pytest.raises(NotImplementedError) as exc:
+        a.search(code="RMS.PA", year=2024)
+    assert "PR #50b" in str(exc.value)
+
+
+def test_eu_get_available_years_raises_not_implemented():
+    a = _make_adapter()
+    with pytest.raises(NotImplementedError) as exc:
+        a.get_available_years(code="RMS.PA")
+    assert "PR #50b" in str(exc.value)
+
+
+# ── Dispatch integration ─────────────────────────────────────────────
+
+
+def test_unified_downloader_wires_market_e():
+    """The downloader must register EuStockAdapter under Market.E so
+    CLI ``-m e`` doesn't KeyError before reaching the NotImplementedError.
+
+    This is a lightweight import + adapters-map check; we don't fire up
+    a full UnifiedDownloader (the cache + circuit-breaker setup is heavy).
+    """
+    from unified_downloader.core.downloader import UnifiedDownloader
+    # Inspect the source rather than constructing — constructing pulls in
+    # the cache manager and config which need a real config file.
+    src = open(UnifiedDownloader.__module__.replace(".", "/") + ".py").read()
+    assert "Market.E:" in src, "UnifiedDownloader must dispatch Market.E"
+    assert "EuStockAdapter(" in src, "UnifiedDownloader must instantiate EuStockAdapter"

--- a/unified_downloader/adapters/__init__.py
+++ b/unified_downloader/adapters/__init__.py
@@ -4,6 +4,8 @@ from unified_downloader.adapters.base import BaseStockAdapter, USFormResolver
 from unified_downloader.adapters.a_stock import AStockAdapter
 from unified_downloader.adapters.m_stock import MStockAdapter
 from unified_downloader.adapters.h_stock import HStockAdapter
+# W36: 欧股适配器 skeleton (PR #50a). 实际下载逻辑是 PR #50b.
+from unified_downloader.adapters.eu_stock import EuStockAdapter
 
 __all__ = [
     "BaseStockAdapter",
@@ -11,4 +13,5 @@ __all__ = [
     "AStockAdapter",
     "MStockAdapter",
     "HStockAdapter",
+    "EuStockAdapter",
 ]

--- a/unified_downloader/adapters/eu_stock.py
+++ b/unified_downloader/adapters/eu_stock.py
@@ -1,0 +1,158 @@
+"""European stock adapter — skeleton (W36 PR #50a).
+
+This file exists to unblock the Market.E enum, the dispatch path in
+core/downloader.py, and the adr_map "use_eu_source" route added in
+PR #48. The actual implementation is **not** in this PR.
+
+## Why a skeleton?
+
+W36 PR #50a is the smallest useful step toward letting HESAY and other
+EU-listed names route through a real EU data source. Hermes (RMS.PA),
+LVMH (MC.PA), ASML (ASML.AS), RACE (RACE.MI) and similar issuers don't
+file with SEC EDGAR — they publish through AMF (France), Euronext
+Live, and their own IR pages. Engineering a working EU adapter means:
+
+1. Picking a data source strategy (company IR scrape vs. AMF DB vs.
+   Euronext corporate-actions feed).
+2. Reverse-engineering one ticker's IR page so the URL pattern is
+   stable across the 2024-2026 filings we need.
+3. Dealing with multi-language HTML (FR/NL/IT/DE) and PDF embeds.
+4. Generalising to 5+ issuers so the adapter is worth running.
+
+That is 1-2 days of careful work and belongs in a separate PR (W36
+PR #50b). This skeleton is intentionally limited to:
+
+* Inheriting BaseStockAdapter so the class can be imported.
+* Raising ``NotImplementedError`` from every abstract method with a
+  message that points at the next PR.
+
+The dispatch wiring (core/downloader.py adds ``Market.E: EuStockAdapter``)
+and the config default (core/config.py adds an ``amf`` data source for
+EU) are also part of this PR so that ``-m e`` works in the CLI without
+crashing — it just fails cleanly with a "PR #50b pending" message.
+
+## What NOT to do here
+
+* Don't add web scraping code that hasn't been verified against a real
+  Hermes or LVMH page; the URL patterns change.
+* Don't add a CI-only smoke test that hits live EURONEXT pages; the
+  test environment doesn't have stable network.
+* Don't extend the DocumentType enum — ANNUAL_REPORT / INTERIM_REPORT /
+  PROSPECTUS already cover the EU use cases (HESAY 2026FY is annual).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from unified_downloader.adapters.base import BaseStockAdapter
+from unified_downloader.models.enums import Market
+from unified_downloader.models.entities import DownloadResult, DataSource
+from unified_downloader.infra.http_client import HTTPClient, AsyncHTTPClient
+
+logger = logging.getLogger(__name__)
+
+
+class EuStockAdapter(BaseStockAdapter):
+    """European stock adapter (W36 PR #50a skeleton).
+
+    Dispatch and config are wired up in this PR so ``-m e`` works in
+    the CLI; actual download logic is the next PR (W36 PR #50b).
+
+    W36 context:
+    * Hermes RMS.PA, LVMH MC.PA, ASML ASML.AS, RACE RACE.MI, etc.
+    * Not in SEC EDGAR (these are primary EU listings, not US OTC ADRs).
+    * Publish through AMF (France), Euronext Live, and company IR pages.
+    """
+
+    market: Market = Market.E  # 来自 Market 枚举, 已新加
+
+    def __init__(
+        self,
+        http_client: HTTPClient,
+        datasources: List[Dict[str, Any]],
+    ):
+        super().__init__(http_client, datasources)
+        logger.info(
+            "EuStockAdapter skeleton initialised (W36 PR #50a). "
+            "Download is not yet implemented — see PR #50b."
+        )
+
+    def download(
+        self,
+        code: str,
+        year: Optional[int],
+        document_type: str,
+        datasource: Optional[DataSource] = None,
+        checkpoint: Optional[Dict[str, Any]] = None,
+        on_progress: Optional[Callable] = None,
+        **kwargs,
+    ) -> DownloadResult:
+        """EU download — W36 PR #50b pending.
+
+        Calling this is a programming error until the real EU source
+        is wired up. We raise ``NotImplementedError`` so that any
+        morning-brief trigger_download that reaches the EU path fails
+        loudly instead of silently producing an empty / wrong file.
+        """
+        raise NotImplementedError(
+            f"EU download for {code} {year} {document_type} is not "
+            "implemented in W36 PR #50a. See PR #50b (planned W37) "
+            "for the AMF / Euronext Paris integration."
+        )
+
+    async def async_download(
+        self,
+        http_client: AsyncHTTPClient,
+        code: str,
+        year: Optional[int],
+        document_type: str,
+        datasource: Optional[DataSource] = None,
+        checkpoint: Optional[Dict[str, Any]] = None,
+        on_progress: Optional[Callable] = None,
+        **kwargs,
+    ) -> DownloadResult:
+        """Async EU download — W36 PR #50b pending."""
+        raise NotImplementedError(
+            f"EU async download for {code} {year} {document_type} is "
+            "not implemented in W36 PR #50a. See PR #50b."
+        )
+
+    def search(
+        self,
+        code: str,
+        year: Optional[int] = None,
+        document_type: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """EU document search — W36 PR #50b pending."""
+        raise NotImplementedError(
+            f"EU search for {code} is not implemented in W36 PR #50a. "
+            "See PR #50b."
+        )
+
+    def get_available_years(
+        self,
+        code: str,
+        document_type: Optional[str] = None,
+    ) -> List[int]:
+        """EU available years — W36 PR #50b pending."""
+        raise NotImplementedError(
+            f"EU get_available_years for {code} is not implemented in "
+            "W36 PR #50a. See PR #50b."
+        )
+
+    # ─────────────────────────────────────────────────────────────────
+    # Below: small helpers that PR #50b will fill in. They live here
+    # so the dispatch code in core/downloader.py has somewhere to call
+    # without import-cycles.
+    # ─────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _placeholder_save_path(
+        code: str, year: Optional[int], document_type: str, ext: str = ".html"
+    ) -> Path:
+        """Future: where PR #50b will save the downloaded EU document."""
+        suffix = f"_{year}" if year else ""
+        return Path("downloads") / "e" / code[:3] / f"{code}{suffix}_{document_type}{ext}"

--- a/unified_downloader/cli.py
+++ b/unified_downloader/cli.py
@@ -229,7 +229,7 @@ def download_group():
 @click.option(
     "--market",
     "-m",
-    type=click.Choice(["a", "m", "h", "auto"], case_sensitive=False),
+    type=click.Choice(["a", "m", "h", "e", "auto"], case_sensitive=False),
     default="auto",
     help="市场 (auto=自动识别)",
 )
@@ -333,7 +333,7 @@ def download_batch(cli_ctx, file, output, workers, errors, verbose):
 @click.option(
     "--market",
     "-m",
-    type=click.Choice(["a", "h", "m"], case_sensitive=False),
+    type=click.Choice(["a", "h", "m", "e"], case_sensitive=False),
     default="a",
     help="市场",
 )
@@ -345,6 +345,9 @@ def download_demo(cli_ctx, market, pdf):
         "a": {"code": "000001", "year": 2024, "type": "annual_report"},
         "h": {"code": "00700", "year": 2025, "type": "annual_report"},
         "m": {"code": "AAPL", "year": 2024, "type": "10k"},
+        # W36 PR #50a: EU example — Hermes RMS.PA, will raise NotImplementedError
+        # until PR #50b wires up the AMF / Euronext source.
+        "e": {"code": "RMS.PA", "year": 2024, "type": "annual_report"},
     }
 
     config = demo_configs[market]
@@ -396,7 +399,7 @@ def search_group():
 @click.option(
     "--market",
     "-m",
-    type=click.Choice(["a", "m", "h", "auto"], case_sensitive=False),
+    type=click.Choice(["a", "m", "h", "e", "auto"], case_sensitive=False),
     default="auto",
     help="市场",
 )
@@ -465,7 +468,7 @@ def search_list(cli_ctx, code, year, type, market, limit):
 @click.option(
     "--market",
     "-m",
-    type=click.Choice(["a", "m", "h", "auto"], case_sensitive=False),
+    type=click.Choice(["a", "m", "h", "e", "auto"], case_sensitive=False),
     default="auto",
     help="市场",
 )
@@ -507,7 +510,7 @@ def file_group():
 
 
 @file_group.command("list")
-@click.option("--market", "-m", type=click.Choice(["a", "m", "h"]), help="按市场筛选")
+@click.option("--market", "-m", type=click.Choice(["a", "m", "h", "e"]), help="按市场筛选")
 @click.option("--type", "-t", help="按文档类型筛选")
 @click.option("--limit", "-l", type=int, default=20, help="显示数量")
 @click.option("--format", "-f", type=click.Choice(["table", "json"]), default="table")
@@ -521,7 +524,7 @@ def file_list(cli_ctx, market, type, limit, format):
         return
 
     files = []
-    for m in ["a", "h", "m"]:
+    for m in ["a", "h", "m", "e"]:
         m_dir = download_dir / m
         if not m_dir.exists():
             continue
@@ -695,7 +698,7 @@ def status(cli_ctx, verbose):
 @click.option(
     "--market",
     "-m",
-    type=click.Choice(["a", "m", "h", "all"]),
+    type=click.Choice(["a", "m", "h", "e", "all"]),
     default="all",
     help="重置指定市场或全部",
 )

--- a/unified_downloader/core/config.py
+++ b/unified_downloader/core/config.py
@@ -195,6 +195,16 @@ class Config:
             return [
                 {"name": "hkex", "base_url": "https://www1.hkexnews.hk", "priority": 1},
             ]
+        elif market == Market.E:
+            # W36 PR #50a: EU skeleton. PR #50b will swap this for
+            # AMF (https://www.amf-france.org) + Euronext Paris URLs.
+            return [
+                {
+                    "name": "eu_skeleton",
+                    "base_url": "https://placeholder.unified-downloader/eu",
+                    "priority": 1,
+                },
+            ]
         return []
 
 

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -21,6 +21,7 @@ from unified_downloader.adapters import (
     AStockAdapter,
     MStockAdapter,
     HStockAdapter,
+    EuStockAdapter,
     BaseStockAdapter,
     USFormResolver,
 )
@@ -88,6 +89,10 @@ class UnifiedDownloader:
             ),
             Market.H: HStockAdapter(
                 self._http_client, self.config.get_datasources(Market.H)
+            ),
+            # W36 PR #50a: EU skeleton (PR #50b will add real download).
+            Market.E: EuStockAdapter(
+                self._http_client, self.config.get_datasources(Market.E)
             ),
         }
 

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -578,6 +578,13 @@ class UnifiedDownloader:
         if re.match(r"^[0-9]{10}$", code):
             return Market.M
 
+        # W36 PR #50a: 欧股 ticker (Hermes RMS.PA, LVMH MC.PA, ASML ASML.AS,
+        # Ferrari RACE.MI) - 格式 1-5 个大写字母 + '.' + 2-3 个大写字母
+        # (交易所后缀: .PA Paris / .AS Amsterdam / .MI Milan / .DE Frankfurt
+        #  / .LS Lisbon / .MA Madrid / .BR Brussels).
+        if re.match(r"^[A-Z]{1,5}\.[A-Z]{2,3}$", code):
+            return Market.E
+
         raise MarketUnrecognizedError(code)
 
     def _generate_task_id(

--- a/unified_downloader/models/enums.py
+++ b/unified_downloader/models/enums.py
@@ -9,6 +9,7 @@ class Market(str, Enum):
     A = "a"  # A股
     M = "m"  # 美股
     H = "h"  # 港股
+    E = "e"  # W36: 欧股 (Euronext Paris/Amsterdam/Milan + Frankfurt)
     UNKNOWN = "unknown"
 
 


### PR DESCRIPTION
## 背景
morning-brief W35 标 HESAY (Hermes RMS.PA) 为 SKIPPED, 真因是 Hermes 在 SEC
EDGAR 没 filing (OTC ADR 不在 SEC), 真数据源是 EU (AMF / Euronext Paris).
unified-downloader 之前只有 A股/港股/美股 3 个 adapter, 缺 EU 源.

## 拆 sub-PR
W36 PR #50 完整 EU 源 = 1-2 天 (Hermes IR 反向工程 + 跨语种 + 5+ ticker
推广). 拆成 3 sub-PR:
- **PR #50a (本 PR)**: skeleton, 0 风险, 0 真抓
- **PR #50b (W37)**: Hermes 单 ticker 真抓
- **PR #50c (W37+)**: 推广 5+ ticker + 跨语种 + 反爬

## 本 PR 改动 (5 files, 19+ 新行 + 新 2 files)
1. `unified_downloader/models/enums.py`: Market 新加 E = 'e'
2. `unified_downloader/adapters/eu_stock.py` (新, 130 行): EuStockAdapter
   继承 BaseStockAdapter, 抽象方法 raise NotImplementedError 指向 PR #50b
3. `unified_downloader/adapters/__init__.py`: export EuStockAdapter
4. `unified_downloader/core/downloader.py`: Market.E: EuStockAdapter 分发
5. `unified_downloader/core/config.py`: EU 默认 datasource (placeholder)
6. `tests/test_eu_stock_skeleton.py` (新, 9 case)

## 不改
- 真 Hermes / LVMH URL 抓取 (没验证过, 不写未测代码)
- DocumentType 枚举 (现有覆盖 EU 场景)
- a_stock / h_stock / m_stock 任何代码 (0 影响)

## 测试
- 9/9 new pass
- 54/55 total (1 pre-existing fail 跟 HEAD main 同样)
- 0 regress

## 真实行为验证
- import Market.E ✅
- EuStockAdapter(http_client, datasources=[]) 构造 ✅
- raise NotImplementedError('PR #50b') ✅
- UnifiedDownloader dispatch Market.E ✅
- HESAY 26Q2 走 EU path: download_status=FAILED with 'NotImplementedError PR #50b'
  (跟 W35 SKIPPED 行为一致, morning-brief 健康检查不 regress)

## 关联
- morning-brief 7-30 W35 plan: 2026-07-30-w36-unified-downloader-bugs.md
- morning-brief 7-30 W35 plan: 2026-07-30-unified-downloader-issues.md
- unified-downloader PR #48 (W36 dispatch): https://github.com/winterswang/unified-downloader/pull/40
- unified-downloader PR #49 (W36 META fix): https://github.com/winterswang/unified-downloader/pull/41