### PR TITLE
feat(m_stock): add custom_ir_source fallback for HESAY 爱马仕(ADR) Hermès (W37-#50b)

### DIFF
--- a/config/adr_map.json
+++ b/config/adr_map.json
@@ -39,6 +39,28 @@
         "2025-02-05": "250205e.pdf (FY25 Q3 detailed, 210 KB)",
         "2026-05-08": "260508e.pdf (FY26 Q4, 922 KB)"
       }
+    },
+    "HESAY.US": {
+      "name": "爱马仕(ADR) Hermès International",
+      "ir_base_url": "https://assets-finance.hermes.com/s3fs-public/node/pdf_file",
+      "sitemap_pdfs": "https://finance.hermes.com/sitemap-pdf.xml",
+      "lang": "en",
+      "fy_end_month": 12,
+      "publish_dates": {
+        "URD": "03-XX"
+      },
+      "verified_pdfs": {
+        "2025-03-28": {
+          "url": "https://assets-finance.hermes.com/s3fs-public/node/pdf_file/2025-05/1746455904/250328_hermes_urd2024_en.pdf",
+          "size": "14.7 MB",
+          "note": "URD 2024 EN (Universal Registration Document 2024, 20 pages preview via web_fetch)"
+        },
+        "2026-03-20": {
+          "url": "https://assets-finance.hermes.com/s3fs-public/node/pdf_file/2026-04/1777391712/260320_hermes_urd2025_en.pdf?VersionId=jE9NgndClrtsqa.kJW0uyG8NRg4SFCVU",
+          "size": "20.2 MB",
+          "note": "URD 2025 EN"
+        }
+      }
     }
   },
 

--- a/tests/test_hermes_ir_fallback.py
+++ b/tests/test_hermes_ir_fallback.py
@@ -1,0 +1,79 @@
+"""W37-#50b: HESAY 爱马仕(ADR) custom_ir_source fallback 回归测试.
+
+Hermès International (RMS.PA Euronext Paris) 在 SEC EDGAR 100% Company not found
+(99% family-owned, 无动机美股二次上市). 走 finance.hermes.com sitemap-pdf.xml
+真源 (跟 7-19 港股 source 同样公开 PDF 直链模式).
+
+跟 W37-#50c (NTDOY 任天堂) 同样 verified_pdfs 模式, 但 URL 模式不一样:
+  - NTDOY: {ir_base}/{yyyy}/{yyyymmdd}{lang}.pdf  (URL 可拼)
+  - HESAY: {ir_base}/{yyyy-mm}/{hhh}/{filename}?VersionId=xxx  (URL 不可拼, 需 dict)
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# adr_map.json 加载 (跟 W36 PR #43 同样 mode)
+ADR_MAP_PATH = Path(__file__).parent.parent / "config" / "adr_map.json"
+
+
+def load_adr_map():
+    with open(ADR_MAP_PATH) as f:
+        return json.load(f)
+
+
+def test_hesay_in_custom_ir_source():
+    """HESAY.US 必须在 custom_ir_source 段, 提供 sitemap_pdfs 跟 verified_pdfs."""
+    adr_map = load_adr_map()
+    cis = adr_map["custom_ir_source"]
+    assert "HESAY.US" in cis, "HESAY.US 必须在 adr_map.custom_ir_source (W37-#50b)"
+    hesay = cis["HESAY.US"]
+    assert "sitemap_pdfs" in hesay, "HESAY 需 sitemap_pdfs 字段找真链"
+    assert "verified_pdfs" in hesay, "HESAY 需 verified_pdfs 字段存真链"
+    assert len(hesay["verified_pdfs"]) >= 2, "HESAY 至少 2 个 verified PDF (URD 2024+2025)"
+
+
+def test_hesay_verified_pdfs_use_dict_format():
+    """HESAY verified_pdfs 必须是 dict 格式 (含 url field), 不是 NTDOY string 模式."""
+    adr_map = load_adr_map()
+    hesay = adr_map["custom_ir_source"]["HESAY.US"]
+    for date, info in hesay["verified_pdfs"].items():
+        assert isinstance(info, dict), f"{date} 必须是 dict, not {type(info).__name__}"
+        assert "url" in info, f"{date} dict 必须有 url field"
+        assert info["url"].startswith("https://assets-finance.hermes.com"), \
+            f"{date} URL 必须在 assets-finance.hermes.com CDN (不是 finance.hermes.com 渲染页)"
+
+
+def test_ntsoy_still_string_format():
+    """NTDOY 仍走 string 模式 (跟 W37-#50c PR #44 同样), 不被 HESAY 改影响."""
+    adr_map = load_adr_map()
+    ntsoy = adr_map["custom_ir_source"]["NTDOY.US"]
+    for date, info in ntsoy["verified_pdfs"].items():
+        assert isinstance(info, str), f"NTDOY {date} 必须仍 string 模式 (W37-#50c PR #44)"
+        assert info.endswith(".pdf"), f"NTDOY {date} 描述必须以 .pdf 结尾"
+
+
+def test_hesay_url_real_hermes_sitemap():
+    """HESAY 真 URL 来自 finance.hermes.com sitemap-pdf.xml 真抓验证."""
+    adr_map = load_adr_map()
+    hesay = adr_map["custom_ir_source"]["HESAY.US"]
+    # sitemap_pdfs URL 必须跟真源一致
+    assert hesay["sitemap_pdfs"] == "https://finance.hermes.com/sitemap-pdf.xml", \
+        "sitemap_pdfs URL 必须是 finance.hermes.com/sitemap-pdf.xml (W37-#50b 8-2 真验证)"
+    # verified URLs 必须包含 assets-finance CDN 路径
+    for date, info in hesay["verified_pdfs"].items():
+        assert "/s3fs-public/node/pdf_file/" in info["url"], \
+            f"{date} URL 必须含 s3fs-public CDN path (Hermès 公开 PDF 真源)"
+
+
+def test_use_sec_20f_only_still_marks_hesay():
+    """use_sec_20f_only 仍标 HESAY (跟 W36 PR #40 同样), custom_ir_source 是 fallback."""
+    adr_map = load_adr_map()
+    assert "HESAY.US" in adr_map["use_sec_20f_only"], \
+        "HESAY.US 必须在 use_sec_20f_only (跟 W36 PR #40 同样), custom_ir_source 是 W37-#50b 新 fallback"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -526,13 +526,23 @@ class MStockAdapter(BaseStockAdapter):
         # W37-#50c: 优先 verified_pdfs 匹配的 (YYMMDD -> URL), 跟
         # 7-19 港股 source 同样“公开 PDF 直链 + 命名规则推断” 模式.
         # 按 year 过滤: year=None 走最新一个; year=2024 只试 2024 公布日.
+        # W37-#50b: verified_pdfs value 支持两种格式:
+        #   - str: 跟 NTDOY 同样 URL 拼凑 (ir_base/{yyyy}/{yyyymmdd}{lang}.pdf)
+        #   - dict: {"url": "...", "size": "...", "note": "..."} 直接拿 url
+        #           用于 HESAY 这种 URL pattern 不规则 (VersionId + assets CDN) 的源.
         candidates = []
         sorted_verified = sorted(verified.items(), reverse=True)  # 倒序, 最新优先
-        for publish_date, info_str in sorted_verified:
-            yyyymmdd = publish_date.replace("-", "")[2:]  # 2024-05-07 -> 240507
+        for publish_date, info in sorted_verified:
             yyyy = publish_date[:4]
             if year is None or yyyy == str(year) or yyyy == str(year + 1):
-                candidates.append((f"{ir_base}/{yyyy}/{yyyymmdd}{pdf_lang}.pdf", info_str))
+                if isinstance(info, dict):
+                    url = info.get("url", "")
+                    note = info.get("note", "")
+                    if url:
+                        candidates.append((url, note))
+                else:
+                    yyyymmdd = publish_date.replace("-", "")[2:]  # 2024-05-07 -> 240507
+                    candidates.append((f"{ir_base}/{yyyy}/{yyyymmdd}{pdf_lang}.pdf", info))
 
         # 最后一手 fallback: 跟年度不匹配时, 试通用 YYMMDD (240507 Q4 / 241105 Q2 / 250204 Q3)
         if year and not candidates:


### PR DESCRIPTION
跟 W36 PR #40 + W37-#50c PR #44 同样 1 ticker fix 模式.

W37-#50b: HESAY (Hermès International RMS.PA Euronext Paris) 在 SEC EDGAR 100% Company not found (99% family-owned, 无动机美股二次上市). 走 finance.hermes.com sitemap-pdf.xml 真源.

3 file 改动:
  - config/adr_map.json: +20 lines HESAY.US (sitemap_pdfs + verified_pdfs dict 模式, URL 含 VersionId)
  - unified_downloader/adapters/m_stock.py: +15 lines (verified_pdfs 两种格式兼容)
  - tests/test_hermes_ir_fallback.py: +80 lines 5 回归测试

E2E 5/5 验证 (跟 W36 PR #40 同样 1 ticker 真抓 ROI):
  - HESAY 2024: 14.0 MB URD 2024 EN 真抓
  - HESAY 2025: 19.3 MB URD 2025 EN 真抓
  - HESAY 重复: cache 命中
  - NTDOY 2024: 仍走 NTDOY string 模式 (不被影响)
  - AAPL/NVO: 仍走 SEC 正常

W36 memory 7-22 'Hermes IR 抗爬虫 (Cloudflare 403)' 不准 - 实际 finance.hermes.com 是 Gatsby 5.13 SSR, sitemap-pdf.xml 公开 579 KB 完整 PDF 链. AMF BALO (W36 标的) 不可达 000 0.

W37 plan status: 3 sub-PR (50b HESAY + 50c NTDOY + 50d EU ticker) 全闭环, W37 100% 成功.