### PR TITLE
fix(tests): bulk_download US 不再 --pdf (commit 38b9f16 7-12 改, IMA HTML 支持) (W38-#50e)

### DIFF
--- a/tests/test_bulk_download_us_quarterly.py
+++ b/tests/test_bulk_download_us_quarterly.py
@@ -128,7 +128,12 @@ def test_set_doc_status_persists_quarterly_form_type_for_fallback_protection():
     assert bulk.should_mark_quarterly_unavailable(state, "2025", "Q1-Q3", "10q") is True
 
 
-def test_download_one_us_uses_pdf_without_disabling_cache(monkeypatch, tmp_path):
+def test_download_one_us_uses_html_not_pdf(monkeypatch, tmp_path):
+    """W38-#50e: 美股下载不再 --pdf (commit 38b9f16 7-12 改: IMA 支持 HTML 上传).
+
+    旧版期望 '--pdf' in calls, 实际 source code 早就不 append. 跟 W36 PR #42 同样
+    test/source 不一致, 改 test 删 '--pdf' 期望, 加 'download' 'single' 验证基本 cmd 存在.
+    """
     bulk = load_bulk_module()
     bulk.log = __import__("logging").getLogger("test-bulk")
     output = tmp_path / "downloads/m/AAP/AAPL_2025_10Q.pdf"
@@ -145,8 +150,10 @@ def test_download_one_us_uses_pdf_without_disabling_cache(monkeypatch, tmp_path)
     monkeypatch.setattr(bulk, "run", fake_run)
 
     assert bulk.download_one("AAPL", "US", "2025", "10q") == output
-    assert "--pdf" in calls[0]
+    # W38: IMA 现在直接支持 HTML 上传, 美股不再 --pdf (commit 38b9f16 7-12 改)
+    assert "--pdf" not in calls[0], "W38: 美股不再 --pdf (commit 38b9f16 7-12 改: IMA HTML 支持)"
     assert "--no-cache" not in calls[0]
+    assert "download" in calls[0] and "single" in calls[0]
 
 
 def test_ima_sync_script_path_can_be_overridden(monkeypatch):


### PR DESCRIPTION
跟 W36 PR #42 review 抓出 5 处 M1 同样修 test (CLI 跟实际不一致回归模式).

W37 18:21 闭环后 7h, 实战可验证 pre-existing fail 1 处:
  test_bulk_download_us_quarterly.py:148 assert '--pdf' in calls[0] 期望错.

**真原因** (commit 38b9f16 7-12 'fix: 美股不再强制转PDF，直接上传内嵌图片的HTML到IMA'):
  source code 早就不 append '--pdf' (IMA 现在直接支持 HTML 上传, 图片已自动 base64 内嵌).

**修法**: 改 test 删 '--pdf' 期望, 加 'download' 'single' 验证基本 cmd 存在.

## 4 EU ticker 全年 batch 验证 (W38-#50e 实战, 28 case)

- LVMUY 2024: ✅ 29.7 MB LVMH URD 2024 EN (Prismic)
- HESAY 2024: ✅ 14.0 MB Hermès URD 2024 EN (sitemap-pdf.xml)
- 24 case 早期 year (2018-2023) ❌ NETWORK_ERROR (verified_pdfs 缺早期, Prismic 不可拼 + Drupal pattern 不一致, P2 长期遗留)

## 0 regress
124/124 tests pass (跟 W36 PR #40 同样 0 regress).