### PR TITLE
fix(m_stock): 6-K 按 report_period 季度窗口选正确财报 (XNET Q2 8-14)

### DIFF
--- a/tests/test_m_stock_6k_report_period_window.py
+++ b/tests/test_m_stock_6k_report_period_window.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for MStockAdapter 6-K report_period window matching.
+
+Regression: 2026-08-14 XNET — 迅雷 6-K exhibit 描述全是通用 "EXHIBIT 99.1",
+document 全是 tmXXX_ex99-1.htm, 不含财报关键词 → _pick_earnings_6k 全 0 分
+→ 回退按 size 选最大, 误选 3-12 的 Q4+FY2025 (size=244676) 而非 8-13 的 Q2
+(size=206088).
+
+修复: _pick_earnings_6k 接受 report_period (如 "2026Q2"), 用 filedAt 日期
+窗口优先匹配目标季度 (季度结束日 + 25~85 天). 窗口内优先选 exhibit 打分最高,
+全 0 分则选 size 最大.
+
+这些测试只测选择逻辑, 不下载真实文件.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import MStockAdapter  # noqa: E402
+
+
+def _mk_filing(accession: str, size: int, filed_at: str = "2026-08-04",
+               exhibits=None, name: str = ""):
+    """构造一条 filing dict（模拟 _search_edgar 返回）。"""
+    return {
+        "ticker": "XNET",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "1510593",
+        "companyName": name or accession,
+        "linkToTxt": f"https://example.com/{accession}/index.html",
+        "linkToHtml": f"https://example.com/{accession}/index.html",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits or [],
+    }
+
+
+# XNET 真实 6-K 列表 (2026, 按日期倒序, 2026-08-14 从 SEC submissions 拉取)
+_XNET_2026_FILINGS = [
+    _mk_filing("0001104659-26-095490", 206088, "2026-08-13",
+               exhibits=[{"url": "https://x/tm2623122d1_ex99-1.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm2623122d1_ex99-1.htm"}]),
+    _mk_filing("0001104659-26-078005", 17272, "2026-06-26",
+               exhibits=[{"url": "https://x/tm2619070d1_ex99-1.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm2619070d1_ex99-1.htm"}]),
+    _mk_filing("0001104659-26-067217", 215461, "2026-05-28",
+               exhibits=[{"url": "https://x/tm2615874d1_ex99-1.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm2615874d1_ex99-1.htm"}]),
+    _mk_filing("0001104659-26-028066", 17632, "2026-03-16",
+               exhibits=[{"url": "https://x/tm268900d1_ex99-1.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm268900d1_ex99-1.htm"}]),
+    _mk_filing("0001104659-26-026698", 244676, "2026-03-12",
+               exhibits=[{"url": "https://x/tm268655d1_ex99-1.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm268655d1_ex99-1.htm"}]),
+    _mk_filing("0001104659-26-022569", 45913, "2026-03-03",
+               exhibits=[{"url": "https://x/tm267857d1_ex99-1.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm267857d1_ex99-1.htm"}]),
+]
+
+
+class TestSixKReportPeriodWindow:
+    """6-K report_period 季度窗口匹配"""
+
+    @pytest.fixture
+    def adapter(self):
+        http_client = MagicMock()
+        datasources: list = []
+        return MStockAdapter(http_client, datasources)
+
+    def test_report_period_q2_selects_aug_q2_not_march_q4(self, adapter):
+        """XNET 2026Q2: 应选 8-13 的 Q2, 而非 3-12 的 Q4+FY2025 (size更大)."""
+        picked = adapter._pick_earnings_6k(_XNET_2026_FILINGS, report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "0001104659-26-095490"
+
+    def test_report_period_q1_selects_may_q1(self, adapter):
+        """XNET 2026Q1: 应选 5-28 的 Q1, 而非 3-12 的 Q4."""
+        picked = adapter._pick_earnings_6k(_XNET_2026_FILINGS, report_period="2026Q1")
+        assert picked is not None
+        assert picked["accessionNo"] == "0001104659-26-067217"
+
+    def test_report_period_fy_falls_back_to_old_logic(self, adapter):
+        """FY 无季度窗口 → 回退旧逻辑 (exhibit 打分 / size)."""
+        # 所有 exhibit 描述通用 → 全 0 分 → 旧逻辑返回 None
+        picked = adapter._pick_earnings_6k(_XNET_2026_FILINGS, report_period="2026FY")
+        # 旧逻辑: 无 exhibit 可打分 → None
+        assert picked is None
+
+    def test_no_report_period_preserves_old_behavior(self, adapter):
+        """不传 report_period → 完全旧逻辑 (兼容 RACE/NVO 现有 case)."""
+        picked = adapter._pick_earnings_6k(_XNET_2026_FILINGS)
+        # 全通用 exhibit → 旧逻辑 None
+        assert picked is None
+
+    def test_q2_window_prefers_exhibit_score_when_available(self, adapter):
+        """窗口内优先选 exhibit 打分最高者."""
+        earnings = _mk_filing(
+            "Q2-EARN", 150000, "2026-08-10",
+            exhibits=[{"url": "https://x/result.htm",
+                       "description": "Second Quarter 2026 Results",
+                       "document": "xq2results.htm"}],
+        )
+        generic = _mk_filing("Q2-GENERIC", 300000, "2026-08-13",
+                             exhibits=[{"url": "https://x/ex99.htm",
+                                        "description": "EXHIBIT 99.1",
+                                        "document": "tm123_ex99-1.htm"}])
+        filings = [generic, earnings]
+        picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "Q2-EARN"
+
+    def test_q2_window_generic_only_selects_largest_in_window(self, adapter):
+        """窗口内全是通用 exhibit → 选窗口内 size 最大 (Q2 8-13 vs Q4 3-12)."""
+        picked = adapter._pick_earnings_6k(_XNET_2026_FILINGS, report_period="2026Q2")
+        assert picked["accessionNo"] == "0001104659-26-095490"
+        # 窗口外 (3-12, size 更大) 不能赢过窗口内
+        assert picked["size"] == 206088

--- a/tests/test_m_stock_6k_report_period_window.py
+++ b/tests/test_m_stock_6k_report_period_window.py
@@ -127,3 +127,42 @@ class TestSixKReportPeriodWindow:
         assert picked["accessionNo"] == "0001104659-26-095490"
         # 窗口外 (3-12, size 更大) 不能赢过窗口内
         assert picked["size"] == 206088
+
+    def test_download_form_size_fallback_selects_largest(self, adapter):
+        """_download_form: _pick_earnings_6k 返回 None 时选 size 最大 filing.
+
+        PR #48 review 建议: 覆盖真实 size 回退路径 (_download_form L490-505),
+        而非只测 Python max() builtin.
+        """
+        from unittest.mock import patch
+
+        # 通用 exhibit → _pick_earnings_6k 全 0 分 → None → 触发 size 回退
+        filings = [
+            _mk_filing("ACC-SMALL", 50000, "2026-08-13",
+                       exhibits=[{"url": "https://x/ex99.htm",
+                                  "description": "EXHIBIT 99.1",
+                                  "document": "tm1_ex99-1.htm"}]),
+            _mk_filing("ACC-BIG", 300000, "2026-07-30",
+                       exhibits=[{"url": "https://x/ex99.htm",
+                                  "description": "EXHIBIT 99.1",
+                                  "document": "tm2_ex99-1.htm"}]),
+            _mk_filing("ACC-MID", 100000, "2026-08-01",
+                       exhibits=[{"url": "https://x/ex99.htm",
+                                  "description": "EXHIBIT 99.1",
+                                  "document": "tm3_ex99-1.htm"}]),
+        ]
+        captured = {}
+
+        def fake_download_filing(filing, ticker, form_type, year, on_progress, checkpoint):
+            captured["filing"] = filing
+            from unified_downloader.models.entities import DownloadResult
+            return DownloadResult(success=True, file_path="/tmp/x.html",
+                                  file_size=0)
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing", side_effect=fake_download_filing):
+            result = adapter._download_form("XNET", "6-K", 2026, None, None)
+
+        assert result.success
+        assert captured["filing"]["accessionNo"] == "ACC-BIG"
+        assert captured["filing"]["size"] == 300000

--- a/tests/test_m_stock_6k_size_fallback.py
+++ b/tests/test_m_stock_6k_size_fallback.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for MStockAdapter 6-K "size-largest fallback" behavior.
+
+Regression: 2026-08-13 NVO — 诺和诺德 6-K 是"单文档结构"（正文=primary doc，
+无独立 EX-99 exhibit），_search_edgar 提取的 _exhibits 为空 → _pick_earnings_6k
+全部 0 分返回 None → 旧逻辑回退 filings[0]（最新一条），抓到 8-10 股票回购
+公告 (24KB) 而非 8-4 完整 Q2 财报 (caq22026.htm 1.73MB) → SUSPICIOUS_TOO_SMALL。
+
+修复: 回退时选 size 最大的 filing（财报正文通常远大于普通公告）。
+
+这些测试只测选择逻辑，不下载真实文件。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import MStockAdapter  # noqa: E402
+
+
+def _mk_filing(accession: str, size: int, filed_at: str = "2026-08-04",
+               exhibits=None, name: str = ""):
+    """构造一条 filing dict（模拟 _search_edgar 返回）。"""
+    return {
+        "ticker": "NVO",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "353278",
+        "companyName": name or accession,
+        "linkToTxt": f"https://example.com/{accession}/index.html",
+        "linkToHtml": f"https://example.com/{accession}/index.html",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits or [],
+    }
+
+
+class TestSixKSizeLargestFallback:
+    """6-K 无 exhibit 时回退选 size 最大的 filing"""
+
+    @pytest.fixture
+    def adapter(self):
+        http_client = MagicMock()
+        datasources: list = []
+        return MStockAdapter(http_client, datasources)
+
+    def test_pick_earnings_returns_none_when_no_exhibits(self, adapter):
+        """所有 filing 无 _exhibits → _pick_earnings_6k 返回 None"""
+        filings = [
+            _mk_filing("A", 167508),
+            _mk_filing("B", 2784789),
+            _mk_filing("C", 167154),
+        ]
+        picked = adapter._pick_earnings_6k(filings)
+        assert picked is None  # 无 exhibit 可打分
+
+    def test_fallback_selects_largest_size(self, adapter):
+        """
+        回退应选 size 最大的 filing（完整财报 2.78MB），
+        而非 filings[0]（回购公告 167KB）。
+        """
+        filings = [
+            _mk_filing("0001171843-26-005376", 167508, "2026-08-10"),  # 回购公告
+            _mk_filing("0000353278-26-000023", 2784789, "2026-08-04"),  # 完整财报
+            _mk_filing("0001171843-26-005184", 167154, "2026-08-04"),  # 摘要
+        ]
+        best = max(filings, key=lambda f: int(f.get("size") or 0))
+        assert best["accessionNo"] == "0000353278-26-000023"
+        assert best["size"] == 2784789
+
+    def test_size_zero_falls_back_to_first(self, adapter):
+        """所有 size=0 时，回退仍取 filings[0]（不 crash）"""
+        filings = [
+            _mk_filing("A", 0),
+            _mk_filing("B", 0),
+            _mk_filing("C", 0),
+        ]
+        best = max(filings, key=lambda f: int(f.get("size") or 0))
+        assert best["accessionNo"] == "A"
+
+    def test_large_exhibit_still_preferred(self, adapter):
+        """有财报 exhibit 的仍优先于 size 回退（关键词打分优先）"""
+        # RACE 场景: 财报 exhibit 含关键词 → 应被选中
+        earnings = _mk_filing(
+            "RACE-EARN", 20000, "2026-07-30",
+            exhibits=[{
+                "url": "https://x/ferrarinvinterimreport-063",
+                "description": "Interim Report",
+                "document": "ferrarinvinterimreport-063.htm",
+            }],
+        )
+        pr = _mk_filing("RACE-PR", 50000, "2026-07-31")  # 更大但无财报 exhibit
+        filings = [pr, earnings]
+        picked = adapter._pick_earnings_6k(filings)
+        assert picked is not None
+        assert picked["accessionNo"] == "RACE-EARN"

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -1,6 +1,7 @@
 """美股适配器 - 使用 edgartools (主) + sec-api (兜底)"""
 
 import asyncio
+import calendar
 import datetime
 import logging
 import os
@@ -582,7 +583,10 @@ class MStockAdapter(BaseStockAdapter):
                     q = m.group(2)
                     if q:
                         month_end = {"1": 3, "2": 6, "3": 9, "4": 12}[q]
-                        target_end = datetime.date(y, month_end, 30)
+                        # off-by-1 修复 (PR #48 review 8-14): 3月=31天, 12月=31天,
+                        # 不能硬编码 day=30 (Q1 会得 Mar30 而非 Mar31, Q4 得 Dec30 而非 Dec31)
+                        last_day = calendar.monthrange(y, month_end)[1]
+                        target_end = datetime.date(y, month_end, last_day)
                     else:
                         # FY 无明确季度 → 用 12-31 (年度报告)
                         target_end = datetime.date(y, 12, 31)

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -461,12 +461,22 @@ class MStockAdapter(BaseStockAdapter):
             )
 
         try:
-            filings = self._search_filings(ticker, form_type, year, size=1)
+            # W39 8-9 RACE 修复: 6-K 是"封面+exhibit"结构, 同一公司一年有几十条 6-K
+            # (普通 PR / 董事会变动 / 财报). 若只取 size=1 (最新一条), 可能取到普通 PR
+            # (如 RACE 7-31 fnvbb310726prex.htm 3KB), 而非 Q2 财报 (7-30 interim report
+            # 209KB 含 revenue/EBITDA). 所以对 6-K 多取几条, 选 exhibit 含财报关键词的.
+            size = 10 if form_type == "6-K" else 1
+            filings = self._search_filings(ticker, form_type, year, size=size)
 
             if not filings:
                 return _try_ir_fallback()
 
             filing = filings[0]
+            if form_type == "6-K" and len(filings) > 1:
+                picked = self._pick_earnings_6k(filings)
+                if picked is not None:
+                    filing = picked
+
             return self._download_filing(
                 filing, ticker, form_type, year, on_progress, checkpoint
             )
@@ -488,6 +498,51 @@ class MStockAdapter(BaseStockAdapter):
             return DownloadResult(
                 success=False, error_code="DOWNLOAD_ERROR", error_message=str(e)
             )
+
+    _EARNINGS_KEYWORDS = (
+        "revenue", "net income", "gross profit", "earnings per share",
+        "diluted", "EBITDA", "operating income", "financial results",
+        "second quarter", "third quarter", "fourth quarter", "first quarter",
+    )
+    # 文件名特征词: 财报型 exhibit 文件名常含这些 (RACE: fnvq22026results /
+    # ferrarinvinterimreport-063; 普通 PR 是 fnvbb...prex)
+    _FILE_EARNINGS_KEYWORDS = (
+        "results", "interim", "quarter", "annual", "report", "earnings",
+        "financial", "fy", "semiannual", "half-year", "halfyear", "semi",
+    )
+
+    def _pick_earnings_6k(
+        self, filings: List[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """从多条 6-K 中选财报特征最强的.
+
+        W39 8-9 RACE 修复: 6-K 是"封面+exhibit"结构, 同一年几十条 6-K
+        (普通 PR / 董事会变动 / 财报). 仅凭日期无法区分. 每条 6-K 的 exhibit
+        (EX-99) 才是真内容. 选 exhibit 文件名+描述含财报关键词最多的那条;
+        若没有, 选 exhibit 最多的那条; 仍没有回退 None (调用方用第一条).
+        """
+        best = None
+        best_score = -1
+        for filing in filings:
+            exhibits = filing.get("_exhibits", [])
+            if not exhibits:
+                continue
+            score = 0
+            # 对每个 exhibit, 从描述+文件名里计财报关键词
+            for ex in exhibits:
+                desc = str(ex.get("description", "")) or ""
+                doc = str(ex.get("document", "")) or ""
+                blob = (desc + " " + doc).lower()
+                score += sum(1 for kw in self._EARNINGS_KEYWORDS if kw in blob)
+                score += sum(1 for kw in self._FILE_EARNINGS_KEYWORDS if kw in blob)
+                # exhibit 大小权重 (财报正文通常更大)
+                ex_size = ex.get("size_bytes", 0) or 0
+                if ex_size:
+                    score += 1 if ex_size > 100_000 else 0
+            if score > best_score:
+                best_score = score
+                best = filing
+        return best if best_score > 0 else None
 
     def _try_custom_ir_source(
         self,
@@ -1070,10 +1125,16 @@ class MStockAdapter(BaseStockAdapter):
                     exhibits = filing.get("_exhibits", [])
                     if exhibits:
                         try:
-                            downloaded_path = self._merge_6k_exhibits(
+                            merged = self._merge_6k_exhibits(
                                 downloaded_path, exhibits, ticker, file_year,
                                 form_type, headers
                             )
+                            # W39 8-9 RACE 修复: merge 返回的才是含财报正文的文件,
+                            # 必须同步 result["file_path"] (否则 return 仍指向封面 15KB)
+                            if merged and merged != downloaded_path:
+                                downloaded_path = merged
+                                result["file_path"] = str(merged)
+                                result["file_size"] = merged.stat().st_size
                         except Exception as e:
                             logger.warning(f"6-K exhibit merge failed, using cover only: {e}")
 

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -251,6 +251,12 @@ class MStockAdapter(BaseStockAdapter):
                     if hasattr(filing, "filing_url")
                     else None,
                     "source": "edgar",
+                    # 单文档 6-K (NVO 等): 正文就是 primary doc, 无独立 EX-99 exhibit.
+                    # 记录 size 供回退时选“最大文件”（财报正文通常远大于普通公告）.
+                    # 2026-08-13 NVO 修复: filing.size 在 edgar 4.x/5.x 均可拿.
+                    "size": getattr(filing, "size", None)
+                    or (len(filing.text or "") if hasattr(filing, "text") else None)
+                    or 0,
                 }
 
                 # 6-K is just a cover page; extract exhibit URLs for the real content
@@ -476,6 +482,24 @@ class MStockAdapter(BaseStockAdapter):
                 picked = self._pick_earnings_6k(filings)
                 if picked is not None:
                     filing = picked
+                else:
+                    # 2026-08-13 NVO 修复: _pick_earnings_6k 对“单文档 6-K”
+                    # (NVO 等, 正文=primary doc, 无独立 EX-99 exhibit) 无 exhibit
+                    # 可打分 → 返回 None → 旧逻辑回退 filings[0] (最新一条),
+                    # 会抓到普通公告 (NVO 8-10 股票回购 24KB) 而非 8-4 完整财报
+                    # (caq22026.htm 1.73MB). 改为选 size 最大的 filing (财报正文
+                    # 通常远大于普通公告/回购公告), 避免 SUSPICIOUS_TOO_SMALL.
+                    best = max(
+                        filings, key=lambda f: int(f.get("size") or 0)
+                    )
+                    if int(best.get("size") or 0) > int(filing.get("size") or 0):
+                        logger.info(
+                            f"[m_stock] 6-K 无财报 exhibit, 选 size 最大 filing: "
+                            f"{best.get('accessionNo')} size={best.get('size')} "
+                            f"(替代 filings[0] {filing.get('accessionNo')} "
+                            f"size={filing.get('size')})"
+                        )
+                        filing = best
 
             return self._download_filing(
                 filing, ticker, form_type, year, on_progress, checkpoint

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -1,8 +1,10 @@
 """美股适配器 - 使用 edgartools (主) + sec-api (兜底)"""
 
 import asyncio
+import datetime
 import logging
 import os
+import re
 import time
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Callable
@@ -142,7 +144,10 @@ class MStockAdapter(BaseStockAdapter):
                 code, document_type, datasource, checkpoint, on_progress
             )
         elif doc_type_lower in ["6k", "8k"]:
-            return self._download_6k(code, year, datasource, checkpoint, on_progress)
+            return self._download_6k(
+                code, year, datasource, checkpoint, on_progress,
+                report_period=kwargs.get("report_period"),
+            )
         elif doc_type_lower in ["20f", "20-f", "twenty_f"]:
             return self._download_form(code, "20-F", year, checkpoint, on_progress)
         else:
@@ -441,6 +446,7 @@ class MStockAdapter(BaseStockAdapter):
         year: Optional[int],
         checkpoint: Optional[Dict[str, Any]],
         on_progress: Optional[Callable],
+        report_period: Optional[str] = None,
     ) -> DownloadResult:
         """下载指定类型SEC文档的通用方法
 
@@ -479,7 +485,7 @@ class MStockAdapter(BaseStockAdapter):
 
             filing = filings[0]
             if form_type == "6-K" and len(filings) > 1:
-                picked = self._pick_earnings_6k(filings)
+                picked = self._pick_earnings_6k(filings, report_period=report_period)
                 if picked is not None:
                     filing = picked
                 else:
@@ -536,7 +542,9 @@ class MStockAdapter(BaseStockAdapter):
     )
 
     def _pick_earnings_6k(
-        self, filings: List[Dict[str, Any]]
+        self,
+        filings: List[Dict[str, Any]],
+        report_period: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """从多条 6-K 中选财报特征最强的.
 
@@ -544,25 +552,111 @@ class MStockAdapter(BaseStockAdapter):
         (普通 PR / 董事会变动 / 财报). 仅凭日期无法区分. 每条 6-K 的 exhibit
         (EX-99) 才是真内容. 选 exhibit 文件名+描述含财报关键词最多的那条;
         若没有, 选 exhibit 最多的那条; 仍没有回退 None (调用方用第一条).
+
+        XNET 8-14 修复: 部分公司 (如迅雷 XNET) 的 6-K exhibit 描述全是通用
+        "EXHIBIT 99.1", document 全是 tmXXX_ex99-1.htm, 不含任何财报关键词
+        → 所有 filing 打分都是 0 → 回退按 size 选最大, 但 size 最大不一定是
+        目标季度 (XNET Q2 8-13 发布 size=206088, Q4+FY2025 3-12 发布
+        size=244676 更大 → 误选 Q4).
+
+        修复策略 (两层):
+        1. 若传了 report_period (如 "2026Q2") 且能解析出目标季度 → 用
+           filedAt 日期窗口优先匹配: 目标季度结束日 + [EARLY_DAYS, LATE_DAYS]
+           天窗口内的 filing 优先. 窗口内选 exhibit 打分最高的; 若窗口内
+           全无 exhibit 可打分, 选窗口内 size 最大的. 这保证 XNET 选到
+           8-13 的 Q2 (窗口 ~7-30~9-18) 而不是 3-12 的 Q4.
+        2. 无 report_period 或窗口无命中 → 回退旧逻辑 (打分 → None).
         """
+        # 目标季度窗口 (季度结束后第 N~M 天发布财报)
+        QUARTER_EARLY_DAYS = 25   # 财报最早可能在季度结束后 ~25 天发布
+        QUARTER_LATE_DAYS = 85    # 最晚在 ~85 天内 (跨季末但未到下一季末)
+
+        # 解析 report_period → 目标季度结束日
+        target_end: Optional[datetime.date] = None
+        if report_period:
+            try:
+                period = report_period.upper()  # e.g. 2026Q2 / 2026FY / 2026H1
+                m = re.match(r"(\d{4})(?:[QH]([1-4]))?", period)
+                if m:
+                    y = int(m.group(1))
+                    q = m.group(2)
+                    if q:
+                        month_end = {"1": 3, "2": 6, "3": 9, "4": 12}[q]
+                        target_end = datetime.date(y, month_end, 30)
+                    else:
+                        # FY 无明确季度 → 用 12-31 (年度报告)
+                        target_end = datetime.date(y, 12, 31)
+            except Exception:
+                target_end = None
+
+        def _filed_at_date(f: Dict[str, Any]) -> Optional[datetime.date]:
+            raw = f.get("filedAt") or f.get("filing_date") or ""
+            if isinstance(raw, datetime.date):
+                return raw
+            try:
+                return datetime.date.fromisoformat(str(raw)[:10])
+            except (ValueError, TypeError):
+                return None
+
+        def _exhibit_score(f: Dict[str, Any]) -> int:
+            """计算 filing 的 exhibit 财报特征分 (旧逻辑)."""
+            score = 0
+            for ex in f.get("_exhibits", []):
+                desc = str(ex.get("description", "")) or ""
+                doc = str(ex.get("document", "")) or ""
+                blob = (desc + " " + doc).lower()
+                score += sum(1 for kw in self._EARNINGS_KEYWORDS if kw in blob)
+                score += sum(1 for kw in self._FILE_EARNINGS_KEYWORDS if kw in blob)
+                ex_size = ex.get("size_bytes", 0) or 0
+                if ex_size:
+                    score += 1 if ex_size > 100_000 else 0
+            return score
+
+        # ── 策略 1: 目标季度日期窗口优先 ──
+        if target_end is not None:
+            window_lo = target_end + datetime.timedelta(days=QUARTER_EARLY_DAYS)
+            window_hi = target_end + datetime.timedelta(days=QUARTER_LATE_DAYS)
+            in_window = []
+            for f in filings:
+                d = _filed_at_date(f)
+                if d is None:
+                    continue
+                if window_lo <= d <= window_hi:
+                    in_window.append(f)
+            if in_window:
+                logger.info(
+                    f"[m_stock] 6-K 目标季度窗口 {window_lo}~{window_hi} "
+                    f"命中 {len(in_window)}/{len(filings)} 条: "
+                    + ", ".join(f.get('accessionNo','?') for f in in_window)
+                )
+                # 窗口内优先选 exhibit 打分最高; 全 0 分则选 size 最大
+                best_in = None
+                best_score_in = -1
+                for f in in_window:
+                    s = _exhibit_score(f)
+                    if s > best_score_in:
+                        best_score_in = s
+                        best_in = f
+                if best_score_in > 0:
+                    return best_in
+                # 全无 exhibit 可打分 → 选窗口内 size 最大
+                best_in = max(
+                    in_window, key=lambda f: int(f.get("size") or 0)
+                )
+                logger.info(
+                    f"[m_stock] 6-K 窗口内无 exhibit 财报分, 选 size 最大: "
+                    f"{best_in.get('accessionNo')} size={best_in.get('size')}"
+                )
+                return best_in
+
+        # ── 策略 2: 旧逻辑 (exhibit 打分, 无窗口) ──
         best = None
         best_score = -1
         for filing in filings:
             exhibits = filing.get("_exhibits", [])
             if not exhibits:
                 continue
-            score = 0
-            # 对每个 exhibit, 从描述+文件名里计财报关键词
-            for ex in exhibits:
-                desc = str(ex.get("description", "")) or ""
-                doc = str(ex.get("document", "")) or ""
-                blob = (desc + " " + doc).lower()
-                score += sum(1 for kw in self._EARNINGS_KEYWORDS if kw in blob)
-                score += sum(1 for kw in self._FILE_EARNINGS_KEYWORDS if kw in blob)
-                # exhibit 大小权重 (财报正文通常更大)
-                ex_size = ex.get("size_bytes", 0) or 0
-                if ex_size:
-                    score += 1 if ex_size > 100_000 else 0
+            score = _exhibit_score(filing)
             if score > best_score:
                 best_score = score
                 best = filing
@@ -862,9 +956,18 @@ class MStockAdapter(BaseStockAdapter):
         datasource: Optional[DataSource],
         checkpoint: Optional[Dict[str, Any]],
         on_progress: Optional[Callable],
+        report_period: Optional[str] = None,
     ) -> DownloadResult:
-        """下载6-K报告（含展品合并）"""
-        return self._download_form(code, "6-K", year, checkpoint, on_progress)
+        """下载6-K报告（含展品合并）
+
+        report_period: 目标报告期, 如 "2026Q2". 传参时 _download_form 会用
+        目标季度日期窗口优先选对应财报 6-K (XNET 修复, 8-14), 避免 exhibit
+        描述都是通用 "EXHIBIT 99.1" 时按 size 选到其他季度.
+        """
+        return self._download_form(
+            code, "6-K", year, checkpoint, on_progress,
+            report_period=report_period,
+        )
 
     def _merge_6k_exhibits(
         self,

--- a/unified_downloader/cli.py
+++ b/unified_downloader/cli.py
@@ -238,8 +238,9 @@ def download_group():
 @click.option("--pdf", is_flag=True, help="将HTML文件自动转换为PDF")
 @click.option("--translate", is_flag=True, help="翻译为中文 (仅美股)")
 @click.option("--verbose", "-v", is_flag=True, help="详细输出")
+@click.option("--report-period", "report_period", default=None, help="目标报告期, 如 2026Q2 / 2026FY (用于6-K按季度窗口选正确财报)")
 @ctx
-def download_single(cli_ctx, code, year, type, market, output, no_cache, pdf, translate, verbose):
+def download_single(cli_ctx, code, year, type, market, output, no_cache, pdf, translate, verbose, report_period):
     """下载单个文档"""
     downloader = cli_ctx.downloader
 
@@ -267,6 +268,7 @@ def download_single(cli_ctx, code, year, type, market, output, no_cache, pdf, tr
         use_cache=not no_cache,
         convert_to_pdf=pdf if pdf else None,
         translate=translate if translate else None,
+        report_period=report_period,
     )
 
     echo_result(result, verbose=verbose)


### PR DESCRIPTION
## 问题

XNET (迅雷) 2026Q2 财报下载被误下成 3-12 的 Q4+FY2025 (size 更大被 size 回退选中):
- XNET 6-K exhibit 描述全是通用 `EXHIBIT 99.1`, 无财报关键词
- `_pick_earnings_6k` 全 0 分 → 回退按 size 最大 → 244676 (Q4) > 206088 (Q2)
- 导致 SUSPICIOUS_COVER_ONLY / 下载内容错季度

## 修复

- `_pick_earnings_6k` 接受 `report_period` (如 `2026Q2`)
- 解析目标季度结束日, filedAt 在 [结束日+25, +85] 天窗口内优先
- 窗口内优先选 exhibit 打分最高, 全 0 分选 size 最大
- 无 report_period → 完全旧逻辑 (兼容 NVO/RACE 现有 case)
- CLI `download single` 加 `--report-period` 选项

## 验证

- 新增 6 个单元测试, **134 passed** 无回归
- 端到端: XNET -t 6k --report-period 2026Q2 → 195KB SECOND QUARTER ENDED JUNE 30 2026 (8-13), verifier SUCCESS