### PR TITLE
fix(P0): 修复 4 项静默错误数据问题 (doc_type 分发 / 8k 误下 6-K / PDF magic 校验 / bulk 失败语义)

### DIFF
--- a/scripts/bulk_download.py
+++ b/scripts/bulk_download.py
@@ -100,6 +100,15 @@ def search_docs(code, market, rtype, limit=50):
     return docs
 
 def download_one(code, market, year, rtype, retries=3):
+    """下载单份文档。返回 (file_path, reason):
+
+    - (path, None)      成功
+    - (None, "not_found") 数据源确认无该文档（输出命中关键词），记 skipped 合理
+    - (None, "failed")  重试耗尽的真实失败（网络/限流/超时/UNEXPECTED_ERROR），
+                        必须按失败处理。W40-#50: 之前与 not_found 混为同一个
+                        None，被记 skipped + 退出码 0 → scheduler 标 done，
+                        真实失败被静默吞掉。
+    """
     flag = MARKET_FLAGS[market]
     for n in range(retries + 1):
         if n > 0:
@@ -124,12 +133,12 @@ def download_one(code, market, year, rtype, retries=3):
             # if market == "US" and fpath.suffix.lower() not in (".pdf",):
             #     log.error("  US download did not produce PDF: %s", fpath)
             #     return None
-            return fpath
+            return fpath, None
         combined = (out+err).lower()
         if any(kw in combined for kw in ["not found","no document","no data","无数据","no matching","暂无"]):
-            return None
+            return None, "not_found"
     log.error("  FAILED after %d retries", retries)
-    return None
+    return None, "failed"
 
 def validate_file(fpath):
     if not fpath or not fpath.exists():
@@ -353,7 +362,7 @@ def process_stock(code, market, name, annual_years=10, quarterly_years=5):
 
         if year in avail:
             log.info("  [%s] Downloading...", year)
-            fpath = download_one(dl_code, search_mkt_for_ann, year, ann_type)
+            fpath, dl_reason = download_one(dl_code, search_mkt_for_ann, year, ann_type)
             if fpath and validate_file(fpath):
                 fsize = fpath.stat().st_size
                 set_doc_status(state, "annual", year, "", "downloaded", fpath, fsize=fsize)
@@ -369,12 +378,19 @@ def process_stock(code, market, name, annual_years=10, quarterly_years=5):
                 set_doc_status(state, "annual", year, "", "download_failed", reason="validation failed")
                 failures.append(f"{year} annual: validation failed")
                 log_failure(code, name, f"{year} annual: validation failed")
+            elif dl_reason == "not_found":
+                set_doc_status(state, "annual", year, "", "skipped", reason="not available")
             else:
-                set_doc_status(state, "annual", year, "", "skipped", reason="download returned no file / not found")
+                # W40-#50: 重试耗尽的真实失败按失败处理（之前记 skipped +
+                # 退出码 0 被 scheduler 标 done 静默吞掉）
+                set_doc_status(state, "annual", year, "", "download_failed",
+                               reason="download failed after retries")
+                failures.append(f"{year} annual: download failed after retries")
+                log_failure(code, name, f"{year} annual: download failed after retries")
         else:
             # Try download anyway
             log.info("  [%s] Not in search, trying...", year)
-            fpath = download_one(dl_code, search_mkt_for_ann, year, ann_type)
+            fpath, dl_reason = download_one(dl_code, search_mkt_for_ann, year, ann_type)
             if fpath and validate_file(fpath):
                 fsize = fpath.stat().st_size
                 set_doc_status(state, "annual", year, "", "downloaded", fpath, fsize=fsize)
@@ -385,10 +401,18 @@ def process_stock(code, market, name, annual_years=10, quarterly_years=5):
                     set_doc_status(state, "annual", year, "", "ima_failed", fpath, fsize=fsize)
                     failures.append(f"{year} annual: IMA upload failed")
             elif fpath:
+                # W40-#50: 与 in-avail 分支对齐，校验失败按失败处理（之前记 skipped）
                 fpath.unlink(missing_ok=True)
-                set_doc_status(state, "annual", year, "", "skipped", reason="download invalid")
-            else:
+                set_doc_status(state, "annual", year, "", "download_failed", reason="validation failed")
+                failures.append(f"{year} annual: validation failed")
+                log_failure(code, name, f"{year} annual: validation failed")
+            elif dl_reason == "not_found":
                 set_doc_status(state, "annual", year, "", "skipped", reason="not available")
+            else:
+                set_doc_status(state, "annual", year, "", "download_failed",
+                               reason="download failed after retries")
+                failures.append(f"{year} annual: download failed after retries")
+                log_failure(code, name, f"{year} annual: download failed after retries")
         save_state(state)
 
     # ── 季报 ──
@@ -409,7 +433,7 @@ def process_stock(code, market, name, annual_years=10, quarterly_years=5):
 
                 if year in avail:
                     log.info("  [%s %s] Downloading...", year, qlabel)
-                    fpath = download_one(dl_code, search_mkt_for_q, year, qtype)
+                    fpath, dl_reason = download_one(dl_code, search_mkt_for_q, year, qtype)
                     if fpath and validate_file(fpath):
                         fsize = fpath.stat().st_size
                         set_doc_status(state, "quarterly", year, qlabel, "downloaded", fpath, fsize=fsize, form_type=qtype)
@@ -422,8 +446,23 @@ def process_stock(code, market, name, annual_years=10, quarterly_years=5):
                     elif fpath:
                         fpath.unlink(missing_ok=True)
                         set_doc_status(state, "quarterly", year, qlabel, "download_failed", reason="validation failed", form_type=qtype)
+                        # W40-#50: 季报校验失败之前不计入 failures（年报分支计），
+                        # 状态误判 ok + 退出码 0
+                        failures.append(f"{year} {qlabel}: validation failed")
+                        log_failure(code, name, f"{year} {qlabel}: validation failed")
+                    elif dl_reason == "not_found":
+                        # 与 not-in-avail 分支同样加防护: 后备 form 的
+                        # "无文档" 不能覆盖另一 form 已记录的失败/成果
+                        if should_mark_quarterly_unavailable(state, year, qlabel, qtype):
+                            set_doc_status(state, "quarterly", year, qlabel, "skipped", reason="not available", form_type=qtype)
+                        else:
+                            log.info("  [%s %s] Not available, keeping existing material result", year, qlabel)
                     else:
-                        set_doc_status(state, "quarterly", year, qlabel, "skipped", reason="not available", form_type=qtype)
+                        # W40-#50: 重试耗尽的真实失败按失败处理（之前记 skipped）
+                        set_doc_status(state, "quarterly", year, qlabel, "download_failed",
+                                       reason="download failed after retries", form_type=qtype)
+                        failures.append(f"{year} {qlabel}: download failed after retries")
+                        log_failure(code, name, f"{year} {qlabel}: download failed after retries")
                 else:
                     if should_mark_quarterly_unavailable(state, year, qlabel, qtype):
                         set_doc_status(state, "quarterly", year, qlabel, "skipped", reason="not available", form_type=qtype)

--- a/tests/test_bulk_download_failure_semantics.py
+++ b/tests/test_bulk_download_failure_semantics.py
@@ -1,0 +1,168 @@
+"""
+Regression tests for bulk_download.py 失败语义 (W40-#50).
+
+之前 download_one 对「数据源确认无文档」和「重试耗尽的真实失败」返回同一个
+None, 调用方一律记 skipped + 退出码 0 → scheduler 标 done, 真实失败
+(网络/限流/超时) 被静默吞掉 (SEC 限流一小时 → 整批 "成功" 但零文件)。
+
+修复后 download_one 返回 (path, reason):
+- (None, "not_found") → skipped (合理)
+- (None, "failed")    → download_failed + failures + 退出码 1
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "bulk_download.py"
+
+
+def load_bulk_module():
+    spec = importlib.util.spec_from_file_location("bulk_download", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.log = logging.getLogger("test-bulk")
+    return module
+
+
+# ── download_one 契约 ──
+
+
+def test_download_one_returns_not_found_on_keyword(monkeypatch, tmp_path):
+    """数据源确认无文档 (关键词命中) → (None, "not_found"), 不重试"""
+    bulk = load_bulk_module()
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+    calls = []
+
+    def fake_run(cmd, timeout=120):
+        calls.append(cmd)
+        return 1, "error: document not found for 2031", ""
+
+    monkeypatch.setattr(bulk, "run", fake_run)
+
+    assert bulk.download_one("AAPL", "US", "2031", "10k") == (None, "not_found")
+    assert len(calls) == 1  # not_found 立即返回, 不烧重试
+
+
+def test_download_one_returns_failed_after_retries(monkeypatch, tmp_path):
+    """重试耗尽且无 not_found 关键词 → (None, "failed") (真实失败)"""
+    bulk = load_bulk_module()
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+    sleeps = []
+
+    def fake_run(cmd, timeout=120):
+        # rc!=0 且输出无关键词: 网络错误/限流/UNEXPECTED_ERROR 场景
+        return 2, "Traceback ... RateLimitError: 429 Too Many Requests", ""
+
+    monkeypatch.setattr(bulk, "run", fake_run)
+    monkeypatch.setattr(bulk.time, "sleep", lambda s: sleeps.append(s))
+
+    result = bulk.download_one("AAPL", "US", "2026", "10k", retries=3)
+
+    assert result == (None, "failed")
+    assert len(sleeps) == 3  # 确实重试满 3 次
+
+
+def test_download_one_success_returns_path_and_none(monkeypatch, tmp_path):
+    bulk = load_bulk_module()
+    output = tmp_path / "downloads/m/AAP/AAPL_2026_10K.html"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(b"<html>" + b"x" * 512 + b"</html>")
+    rel = output.relative_to(tmp_path)
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+
+    def fake_run(cmd, timeout=120):
+        return 0, f"✓ 下载成功\n  文件: {rel}", ""
+
+    monkeypatch.setattr(bulk, "run", fake_run)
+
+    assert bulk.download_one("AAPL", "US", "2026", "10k") == (output, None)
+
+
+# ── process_stock 级: 真实失败必须进 failures (退出码非 0 的来源) ──
+
+
+def _patch_bulk_for_process_stock(monkeypatch, tmp_path, download_one_result):
+    """把 process_stock 的外部依赖全部打桩, 只测年度循环的失败标记逻辑"""
+    bulk = load_bulk_module()
+
+    monkeypatch.setattr(bulk, "STATE_DIR", tmp_path / "bulk_state")
+    monkeypatch.setattr(bulk, "LOG_DIR", tmp_path / "logs")
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+
+    # adr_map 解析: 纯美股, 无 ADR 特殊路由
+    monkeypatch.setattr(bulk, "load_adr_map", lambda: {})
+    monkeypatch.setattr(
+        bulk, "resolve_target", lambda code, market, m: (code, "US", False, False)
+    )
+
+    cur_year = 2026
+    monkeypatch.setattr(
+        bulk, "search_docs", lambda *a, **k: [(str(cur_year), "10-K - 2026-02-01")]
+    )
+    monkeypatch.setattr(
+        bulk, "download_one", lambda *a, **k: download_one_result
+    )
+    monkeypatch.setattr(bulk, "upload_ima", lambda *a, **k: True)
+    return bulk
+
+
+def test_real_download_failure_marks_failed_and_partial(monkeypatch, tmp_path):
+    """重试耗尽 → download_failed + failures + status=partial_failure (退出码 1)"""
+    bulk = _patch_bulk_for_process_stock(monkeypatch, tmp_path, (None, "failed"))
+
+    state = bulk.process_stock(
+        "AAPL", "US", "Apple", annual_years=1, quarterly_years=0
+    )
+
+    entry = state["annual"]["2026"]
+    assert entry["status"] == "download_failed"
+    assert entry["reason"] == "download failed after retries"
+    assert any("2026 annual: download failed after retries" in f for f in state["failures"])
+    assert state["status"] == "partial_failure"  # main() 据此退出码 1
+
+
+def test_genuine_not_found_still_marks_skipped(monkeypatch, tmp_path):
+    """数据源确认无文档 → 维持 skipped + status ok (不误报失败)"""
+    bulk = _patch_bulk_for_process_stock(monkeypatch, tmp_path, (None, "not_found"))
+
+    state = bulk.process_stock(
+        "AAPL", "US", "Apple", annual_years=1, quarterly_years=0
+    )
+
+    entry = state["annual"]["2026"]
+    assert entry["status"] == "skipped"
+    assert state["status"] == "ok"
+    assert state["failures"] == []
+
+
+def test_quarterly_validation_failure_counts_as_failure(monkeypatch, tmp_path):
+    """季报 validation 失败之前不计入 failures (年报分支计), 状态误判 ok"""
+    bulk = _patch_bulk_for_process_stock(monkeypatch, tmp_path, (None, "not_found"))
+
+    # 季报: 搜索显示 2026 可用, 但下载回来的是无效文件 (校验失败)
+    bad_file = tmp_path / "downloads/m/AAP/AAPL_2026_10Q.html"
+    bad_file.parent.mkdir(parents=True, exist_ok=True)
+    bad_file.write_bytes(b"<html>Access Denied</html>")  # validate_file 会拒绝
+
+    def fake_download_one(code, market, year, rtype, retries=3):
+        if rtype == "10q":
+            return bad_file, None  # 下载"成功"但内容无效
+        return None, "not_found"
+
+    monkeypatch.setattr(bulk, "download_one", fake_download_one)
+
+    state = bulk.process_stock(
+        "AAPL", "US", "Apple", annual_years=0, quarterly_years=1
+    )
+
+    q_entry = state["quarterly"]["2026"]["Q1-Q3"]
+    assert q_entry["status"] == "download_failed"
+    assert q_entry["reason"] == "validation failed"
+    assert any("2026 Q1-Q3: validation failed" in f for f in state["failures"])
+    assert state["status"] == "partial_failure"
+    assert not bad_file.exists()  # 无效文件已删除

--- a/tests/test_bulk_download_us_quarterly.py
+++ b/tests/test_bulk_download_us_quarterly.py
@@ -149,7 +149,7 @@ def test_download_one_us_uses_html_not_pdf(monkeypatch, tmp_path):
 
     monkeypatch.setattr(bulk, "run", fake_run)
 
-    assert bulk.download_one("AAPL", "US", "2025", "10q") == output
+    assert bulk.download_one("AAPL", "US", "2025", "10q") == (output, None)
     # W38: IMA 现在直接支持 HTML 上传, 美股不再 --pdf (commit 38b9f16 7-12 改)
     assert "--pdf" not in calls[0], "W38: 美股不再 --pdf (commit 38b9f16 7-12 改: IMA HTML 支持)"
     assert "--no-cache" not in calls[0]

--- a/tests/test_m_stock_doc_type_dispatch.py
+++ b/tests/test_m_stock_doc_type_dispatch.py
@@ -1,0 +1,158 @@
+"""
+Unit tests for MStockAdapter download()/async_download() doc_type 分发.
+
+Regression (W40-#50, review finding: 静默错误数据):
+- quarterly/interim_report/q1_report/q3_report 是 CLI -t 允许的类型,
+  之前在 sync 分发里落到 else 分支被当 10-K 年报下载 (要季报给年报,
+  文件名标 20F, 成功无告警)。
+- sync "8k" 之前跟 "6k" 一起进 _download_6k (内部硬编码 "6-K"),
+  而 async 路径正确下载 8-K — 同一调用两个入口行为相反。
+- 未知类型之前静默按 10-K 下载, 现在显式抛 UnsupportedOperationError。
+
+这些测试只测分发路由, 不下载真实文件。
+"""
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import MStockAdapter  # noqa: E402
+# 注意: 异常类必须走 unified_downloader.exceptions 导入 (m_stock 内部同一路径),
+# 否则 sys.path 双入口会产生两个模块实例, pytest.raises 接不住
+from unified_downloader.exceptions import UnsupportedOperationError  # noqa: E402
+
+
+@pytest.fixture
+def adapter():
+    """构造一个 MStockAdapter mock 桩 (只测分发, 不下载)"""
+    return MStockAdapter(MagicMock(), [])
+
+
+class TestSyncDispatch:
+    """download() 的 doc_type → 内部方法路由"""
+
+    @pytest.mark.parametrize(
+        "doc_type",
+        ["quarterly", "interim_report", "q1_report", "q3_report", "10q", "ten_q"],
+    )
+    def test_quarterly_family_routes_to_10q(self, adapter, doc_type):
+        """季报家族必须路由到 _download_10q, 绝不能落 10-K (回归核心)"""
+        with patch.object(adapter, "_download_10q") as mock_q, \
+             patch.object(adapter, "_download_10k") as mock_k:
+            mock_q.return_value = "SENTINEL_10Q"
+            result = adapter.download("AAPL", 2026, doc_type)
+
+            assert result == "SENTINEL_10Q"
+            mock_q.assert_called_once()
+            mock_k.assert_not_called(), (
+                f"{doc_type} 之前落 else 分支被当 10-K 年报下载 (W40-#50 回归点)"
+            )
+
+    @pytest.mark.parametrize("doc_type", ["10k", "ten_k", "annual_report"])
+    def test_annual_family_routes_to_10k(self, adapter, doc_type):
+        """annual_report 是 CLI/MCP 默认类型, 必须显式路由到 10-K"""
+        with patch.object(adapter, "_download_10k") as mock_k:
+            mock_k.return_value = "SENTINEL_10K"
+            result = adapter.download("AAPL", 2026, doc_type)
+
+            assert result == "SENTINEL_10K"
+            mock_k.assert_called_once()
+
+    def test_8k_routes_to_8k_form_not_6k(self, adapter):
+        """"8k" 必须下载 8-K, 不能进 _download_6k (内部硬编码 6-K)"""
+        with patch.object(adapter, "_download_form") as mock_form, \
+             patch.object(adapter, "_download_6k") as mock_6k:
+            mock_form.return_value = "SENTINEL_8K"
+            result = adapter.download("AAPL", 2026, "8k")
+
+            assert result == "SENTINEL_8K"
+            mock_6k.assert_not_called(), (
+                "sync '8k' 之前进 _download_6k 实际下载 6-K (W40-#50 回归点)"
+            )
+            mock_form.assert_called_once()
+            assert mock_form.call_args.args[1] == "8-K"
+
+    def test_6k_routes_to_6k(self, adapter):
+        """"6k" 保持走 _download_6k (带 report_period 财报窗口逻辑)"""
+        with patch.object(adapter, "_download_6k") as mock_6k:
+            mock_6k.return_value = "SENTINEL_6K"
+            result = adapter.download("AAPL", 2026, "6k", report_period="2026Q2")
+
+            assert result == "SENTINEL_6K"
+            mock_6k.assert_called_once()
+            assert mock_6k.call_args.kwargs.get("report_period") == "2026Q2"
+
+    def test_unknown_type_raises(self, adapter):
+        """未知类型显式报错, 不再静默按 10-K 下载 (错误数据入库)"""
+        with patch.object(adapter, "_download_10k") as mock_k:
+            with pytest.raises(UnsupportedOperationError):
+                adapter.download("AAPL", 2026, "bogus_type")
+            mock_k.assert_not_called()
+
+
+class TestAsyncDispatch:
+    """async_download() 的 doc_type 路由必须与 sync 一致"""
+
+    def _run(self, adapter, doc_type):
+        return asyncio.run(
+            adapter.async_download(MagicMock(), "AAPL", 2026, doc_type)
+        )
+
+    @pytest.mark.parametrize(
+        "doc_type", ["quarterly", "interim_report", "q1_report", "q3_report"]
+    )
+    def test_quarterly_family_routes_to_async_10q(self, adapter, doc_type):
+        with patch.object(
+            adapter, "_async_download_10q", new_callable=AsyncMock
+        ) as mock_q, patch.object(
+            adapter, "_async_download_10k", new_callable=AsyncMock
+        ) as mock_k:
+            mock_q.return_value = "SENTINEL_A10Q"
+            result = self._run(adapter, doc_type)
+
+            assert result == "SENTINEL_A10Q"
+            mock_q.assert_awaited_once()
+            mock_k.assert_not_awaited()
+
+    def test_8k_routes_to_8k_form(self, adapter):
+        with patch.object(
+            adapter, "_async_download_form", new_callable=AsyncMock
+        ) as mock_form:
+            mock_form.return_value = "SENTINEL_A8K"
+            result = self._run(adapter, "8k")
+
+            assert result == "SENTINEL_A8K"
+            mock_form.assert_awaited_once()
+            assert mock_form.call_args.args[2] == "8-K"
+
+    def test_unknown_type_raises(self, adapter):
+        with pytest.raises(UnsupportedOperationError):
+            self._run(adapter, "bogus_type")
+
+
+class TestDispatchConstants:
+    """分发表常量与 CLI 允许集的一致性 (cli.py click.Choice 的 m_stock 相关类型)"""
+
+    def test_all_cli_doc_types_are_routable(self):
+        """cli.py -t 允许的每个类型都必须命中某条分发分支, 不许落 else 报错"""
+        cli_types = {
+            "annual_report", "interim_report", "quarterly", "q1_report",
+            "q3_report", "prospectus", "10k", "10q", "s1", "s1a", "f1",
+            "424b4", "6k", "8k", "20f",
+        }
+        routable = (
+            MStockAdapter._ANNUAL_DOC_TYPES
+            | MStockAdapter._QUARTERLY_DOC_TYPES
+            | MStockAdapter._PROSPECTUS_DOC_TYPES
+            | MStockAdapter._TWENTY_F_DOC_TYPES
+            | {"6k", "8k"}
+        )
+        unroutable = cli_types - routable
+        assert not unroutable, (
+            f"CLI 允许但 m_stock 分发不认识的类型: {unroutable} "
+            f"(会在运行时抛 UnsupportedOperationError)"
+        )

--- a/tests/test_m_stock_pdf_direct_magic.py
+++ b/tests/test_m_stock_pdf_direct_magic.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for MStockAdapter._download_pdf_direct 的 %PDF- magic 校验.
+
+Regression (W40-#50): custom_ir_source 兜底之前唯一真实性校验是
+file_size < 1000 — 大于 1KB 的品牌化 404/redirect HTML 页会被原样存成
+.pdf 且 success=True 直接入库 (错误数据)。修复后要求前 1024 字节内
+出现 %PDF- magic (PDF spec 允许 header 前有少量垃圾字节)。
+
+这些测试只测校验逻辑, 不下载真实文件。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import MStockAdapter  # noqa: E402
+
+
+@pytest.fixture
+def adapter():
+    return MStockAdapter(MagicMock(), [])
+
+
+def _run_download(adapter, tmp_path, content: bytes):
+    """让 _download_pdf_direct 把 '下载结果' 写到 tmp_path/out.pdf 再校验"""
+    target = tmp_path / "out.pdf"
+
+    def fake_download(url, file_path):
+        Path(file_path).write_bytes(content)
+        return {"file_path": file_path, "file_size": len(content)}
+
+    with patch.object(adapter, "_build_file_path", return_value=target), \
+         patch.object(adapter, "_http_client") as http:
+        http.download_file.side_effect = fake_download
+        return adapter._download_pdf_direct(
+            url="https://ir.example.com/2026/report.pdf",
+            ticker="TEST",
+            year=2026,
+            source_label="custom_ir_source",
+        )
+
+
+class TestPdfMagicValidation:
+
+    def test_brand_404_html_page_rejected(self, adapter, tmp_path):
+        """>1KB 的 HTML 错误页不能被当 PDF success 入库 (回归核心)"""
+        html = b"<html><body>Company IR - Page Not Found</body>" + b"<!-- padding -->" * 200
+
+        result = _run_download(adapter, tmp_path, html)
+
+        assert result.success is False
+        assert result.error_code == "PDF_INVALID_CONTENT"
+        # 假 PDF 文件必须删除, 不留在 downloads/ 里
+        assert not (tmp_path / "out.pdf").exists()
+
+    def test_small_page_still_rejected_by_size(self, adapter, tmp_path):
+        """<1KB 的 404 页维持原有 PDF_TOO_SMALL 拒绝"""
+        result = _run_download(adapter, tmp_path, b"%PDF-1.4 short")
+
+        assert result.success is False
+        assert result.error_code == "PDF_TOO_SMALL"
+
+    def test_real_pdf_accepted(self, adapter, tmp_path):
+        """正常 PDF (magic 在文件头) 通过"""
+        pdf = b"%PDF-1.7\n%" + b"\xff\xff\xff\xff" * 512  # >1KB
+
+        result = _run_download(adapter, tmp_path, pdf)
+
+        assert result.success is True
+        assert result.error_code == "" or result.error_code is None
+        assert (tmp_path / "out.pdf").exists()
+
+    def test_pdf_with_junk_prefix_accepted(self, adapter, tmp_path):
+        """spec 允许 %PDF- header 出现在前 1024 字节内 (前缀有垃圾字节仍算合法)"""
+        pdf = b"junk-prefix" * 8 + b"%PDF-1.4\n" + b"%" * 2048
+
+        result = _run_download(adapter, tmp_path, pdf)
+
+        assert result.success is True
+
+    def test_html_with_pdf_word_but_no_magic_rejected(self, adapter, tmp_path):
+        """正文里提到 'PDF' 字样但没有 magic header 的 HTML 仍拒绝"""
+        html = (
+            b"<html><body>Download our annual PDF report here</body>"
+            + b"filler " * 512
+        )
+
+        result = _run_download(adapter, tmp_path, html)
+
+        assert result.success is False
+        assert result.error_code == "PDF_INVALID_CONTENT"
+        assert not (tmp_path / "out.pdf").exists()

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -21,6 +21,7 @@ from unified_downloader.exceptions import (
     NetworkError,
     ConversionError,
     TranslationError,
+    UnsupportedOperationError,
 )
 
 logger = logging.getLogger(__name__)
@@ -136,23 +137,34 @@ class MStockAdapter(BaseStockAdapter):
         """下载美股文档"""
         doc_type_lower = document_type.lower()
 
-        if doc_type_lower in ["10k", "ten_k"]:
+        if doc_type_lower in self._ANNUAL_DOC_TYPES:
             return self._download_10k(code, year, datasource, checkpoint, on_progress, **kwargs)
-        elif doc_type_lower in ["10q", "ten_q"]:
+        elif doc_type_lower in self._QUARTERLY_DOC_TYPES:
+            # W40-#50: quarterly/interim_report/q1_report/q3_report 之前落 else
+            # 分支被当 10-K 年报下载（要季报给年报, 文件名标 20F, 无告警）
             return self._download_10q(code, year, datasource, checkpoint, on_progress, **kwargs)
-        elif doc_type_lower in ["s1", "s1a", "f1", "424b4", "prospectus"]:
+        elif doc_type_lower in self._PROSPECTUS_DOC_TYPES:
             return self._download_prospectus(
                 code, document_type, datasource, checkpoint, on_progress
             )
-        elif doc_type_lower in ["6k", "8k"]:
+        elif doc_type_lower == "6k":
             return self._download_6k(
                 code, year, datasource, checkpoint, on_progress,
                 report_period=kwargs.get("report_period"),
             )
-        elif doc_type_lower in ["20f", "20-f", "twenty_f"]:
+        elif doc_type_lower == "8k":
+            # W40-#50: 8-K 之前跟 6k 一起进 _download_6k（内部硬编码 "6-K"），
+            # sync 下载 6-K 而 async 下载 8-K, 同一调用两个入口行为相反
+            return self._download_form(code, "8-K", year, checkpoint, on_progress)
+        elif doc_type_lower in self._TWENTY_F_DOC_TYPES:
             return self._download_form(code, "20-F", year, checkpoint, on_progress)
         else:
-            return self._download_10k(code, year, datasource, checkpoint, on_progress, **kwargs)
+            # W40-#50: 未知类型不再静默按 10-K 下载（错误数据入库），显式报错
+            raise UnsupportedOperationError(
+                f"美股市场不支持的文档类型: {document_type}"
+                f"（支持: 10k/annual_report, 10q/quarterly/q1_report/q3_report/"
+                f"interim_report, 6k, 8k, 20f, s1/f1/424b4/prospectus）"
+            )
 
     async def async_download(
         self,
@@ -168,29 +180,33 @@ class MStockAdapter(BaseStockAdapter):
         """异步下载美股文档"""
         doc_type_lower = document_type.lower()
 
-        if doc_type_lower in ["10k", "ten_k"]:
+        if doc_type_lower in self._ANNUAL_DOC_TYPES:
             return await self._async_download_10k(
                 http_client, code, year, datasource, checkpoint, on_progress, **kwargs
             )
-        elif doc_type_lower in ["10q", "ten_q"]:
+        elif doc_type_lower in self._QUARTERLY_DOC_TYPES:
+            # W40-#50: 与 sync 分发对齐（之前 quarterly 家族落 else 被当 10-K）
             return await self._async_download_10q(
                 http_client, code, year, datasource, checkpoint, on_progress, **kwargs
             )
-        elif doc_type_lower in ["s1", "s1a", "f1", "424b4", "prospectus"]:
+        elif doc_type_lower in self._PROSPECTUS_DOC_TYPES:
             return await self._async_download_prospectus(
                 http_client, code, document_type, datasource, checkpoint, on_progress
             )
-        elif doc_type_lower in ["6k", "8k"]:
+        elif doc_type_lower in ("6k", "8k"):
             return await self._async_download_form(
                 http_client, code, "6-K" if doc_type_lower == "6k" else "8-K", year, checkpoint, on_progress
             )
-        elif doc_type_lower in ["20f", "20-f", "twenty_f"]:
+        elif doc_type_lower in self._TWENTY_F_DOC_TYPES:
             return await self._async_download_form(
                 http_client, code, "20-F", year, checkpoint, on_progress
             )
         else:
-            return await self._async_download_10k(
-                http_client, code, year, datasource, checkpoint, on_progress, **kwargs
+            # W40-#50: 未知类型不再静默按 10-K 下载，显式报错（与 sync 一致）
+            raise UnsupportedOperationError(
+                f"美股市场不支持的文档类型: {document_type}"
+                f"（支持: 10k/annual_report, 10q/quarterly/q1_report/q3_report/"
+                f"interim_report, 6k, 8k, 20f, s1/f1/424b4/prospectus）"
             )
 
     def _search_edgar(
@@ -788,6 +804,29 @@ class MStockAdapter(BaseStockAdapter):
                     success=False,
                     error_code="PDF_TOO_SMALL",
                     error_message=f"{url} returned {file_size} bytes (< 1KB, likely 404 page)",
+                )
+
+            # W40-#50: >1KB 的品牌化 404/HTML 错误页之前被当 PDF success 入库。
+            # 校验 %PDF- magic header（PDF spec 允许 header 出现在前 1024 字节内，
+            # 兼容前面有少量垃圾字节的合法 PDF）。
+            try:
+                with open(file_path, "rb") as f:
+                    head = f.read(1024)
+            except OSError as read_err:
+                return DownloadResult(
+                    success=False,
+                    error_code="CUSTOM_IR_DOWNLOAD_ERROR",
+                    error_message=f"{url} read-back failed: {read_err}",
+                )
+            if b"%PDF-" not in head:
+                file_path.unlink(missing_ok=True)
+                return DownloadResult(
+                    success=False,
+                    error_code="PDF_INVALID_CONTENT",
+                    error_message=(
+                        f"{url} returned non-PDF content "
+                        f"(no %PDF- header in first 1024 bytes, likely HTML error page)"
+                    ),
                 )
 
             return DownloadResult(
@@ -1573,6 +1612,17 @@ class MStockAdapter(BaseStockAdapter):
     # 触发 IMA 后端不索引 body content（仅 record 元数据）
     # 招股书图片重要性低，跳过 embed 直接传主 HTML 即可
     _PROSPECTUS_FORMS = frozenset({"S-1", "S-1/A", "F-1", "F-1/A", "424B4", "424B3", "424B5"})
+
+    # W40-#50: download()/async_download() 共用的 doc_type 分发表（防 sync/async drift）。
+    # 回归背景: quarterly/interim_report/q1_report/q3_report 是 CLI -t 允许的类型,
+    # 之前在 sync 分发里落到 else 分支被当 10-K 年报下载（要季报给年报, 无告警）;
+    # annual_report 是 CLI/MCP 的默认类型, 必须显式映射而不是靠 else 兜底。
+    _ANNUAL_DOC_TYPES = frozenset({"10k", "ten_k", "annual_report"})
+    _QUARTERLY_DOC_TYPES = frozenset(
+        {"10q", "ten_q", "quarterly", "q1_report", "q3_report", "interim_report"}
+    )
+    _PROSPECTUS_DOC_TYPES = frozenset({"s1", "s1a", "f1", "424b4", "prospectus"})
+    _TWENTY_F_DOC_TYPES = frozenset({"20f", "20-f", "twenty_f"})
 
     @classmethod
     def _normalize_form_type(cls, form_type: str) -> str:


### PR DESCRIPTION
## 背景

全仓库 code review (#50) 发现的最危险一类问题：**静默产出错误数据**——不崩溃、不报错，但结果是错的。本 PR 修复其中的 4 个 P0。

## 修复内容

### 1. doc_type 分发黑洞（`m_stock.py`）
- **之前**：CLI 允许的 `quarterly`/`interim_report`/`q1_report`/`q3_report` 在 sync 分发里落到 else 分支，被当 **10-K 年报**下载——要季报给年报，文件名标 20F，成功无告警
- **修复**：分发统一用类级常量（`_ANNUAL_DOC_TYPES` / `_QUARTERLY_DOC_TYPES` 等），sync/async 共用防 drift；`annual_report`（CLI/MCP 默认类型）显式映射到 10-K；未知类型改为显式抛 `UnsupportedOperationError`，不再静默按 10-K 下载

### 2. sync "8k" 实际下载 6-K（`m_stock.py`）
- **之前**：dispatch 把 `["6k","8k"]` 都送进 `_download_6k`（内部硬编码 "6-K"），sync 下载 6-K 而 async 正确下载 8-K——同一调用两个入口行为相反
- **修复**：`8k` 单独走 `_download_form(code, "8-K", ...)`，与 async 对齐

### 3. custom_ir_source 把错误页当 PDF（`m_stock.py`）
- **之前**：唯一真实性校验是 `file_size < 1000`，大于 1KB 的品牌化 404/redirect HTML 页会存成 `.pdf` 且 `success=True` 直接入库
- **修复**：加 `%PDF-` magic 校验（前 1024 字节内出现即合法，兼容 header 前有少量垃圾字节的 PDF）；非 PDF 内容返回 `PDF_INVALID_CONTENT` 并删除假文件

### 4. 批量下载失败语义（`scripts/bulk_download.py`）
- **之前**：`download_one` 对「数据源确认无文档」和「重试耗尽的真实失败」返回同一个 `None`，调用方一律记 `skipped` + 退出码 0 → scheduler 标 `done`。SEC 限流一小时 → 整批"成功"但零文件
- **修复**：`download_one` 返回 `(path, reason)` 三态契约：`not_found`（关键词命中）→ skipped；`failed`（重试耗尽）→ `download_failed` + failures + 退出码 1。附带：季报 validation 失败补计 failures（年报分支本来就计）；年报 not-in-avail 分支校验失败与 in-avail 对齐；季报 not_found 加 `should_mark_quarterly_unavailable` 防护，后备 form 的"无文档"不覆盖另一 form 已记录的失败

## 测试

- 新增 `test_m_stock_doc_type_dispatch.py`（22 用例：sync/async 路由、未知类型报错、CLI 类型全覆盖一致性）
- 新增 `test_m_stock_pdf_direct_magic.py`（5 用例：404 页拒绝、真 PDF 通过、垃圾前缀 PDF 通过）
- 新增 `test_bulk_download_failure_semantics.py`（6 用例：三态契约、process_stock 级失败标记、not_found 不误报）
- 更新 `test_bulk_download_us_quarterly.py`（download_one 新契约）
- 全量 **165 passed**

Closes 部分 #50（P0 四项勾选后见 issue）