### PR TITLE
fix(P1): bulk 编排可靠性 — 超时隔离 / failed 可重试 / 原子写状态 / IMA 查找链

### DIFF
--- a/scripts/bulk_download.py
+++ b/scripts/bulk_download.py
@@ -50,9 +50,23 @@ log = logging.getLogger("bulk")
 # ── 路径常量 ──
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
-DEFAULT_IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
-IMA_SYNC_SCRIPT = Path(os.environ.get("IMA_SYNC_SCRIPT_PATH", DEFAULT_IMA_SYNC_SCRIPT))
+# W40-#50 P1: 旧默认路径在仓库外 (~/.openclaw/...), 不在版本控制,
+# 新机器部署即所有 IMA 上传失败。标准位置是仓库内 scripts/sync_to_ima.sh
+# (需从服务器 ~/.openclaw 拷一次进来, 见 issue #50), 旧路径仅作 fallback。
+LEGACY_IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
 TZ_CN = timezone(timedelta(hours=8))
+
+
+def _resolve_ima_script() -> Path:
+    """IMA 同步脚本查找链: 环境变量 → 仓库内 scripts/sync_to_ima.sh →
+    旧 ~/.openclaw 路径。调用时解析 (非模块加载时), 进程内改 env 也生效。"""
+    env = os.environ.get("IMA_SYNC_SCRIPT_PATH")
+    if env:
+        return Path(env)
+    in_repo = PROJECT_ROOT / "scripts" / "sync_to_ima.sh"
+    if in_repo.exists():
+        return in_repo
+    return LEGACY_IMA_SYNC_SCRIPT
 
 ANNUAL_MAP = {"CN": "annual_report", "HK": "annual_report", "US": "10k", "US_20F": "20f"}
 QUARTERLY_MAP = {
@@ -67,8 +81,45 @@ MARKET_FLAGS = {"CN": "a", "HK": "h", "US": "m"}
 
 
 def run(cmd, timeout=120):
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd=str(PROJECT_ROOT))
-    return r.returncode, r.stdout.strip(), r.stderr.strip()
+    """跑子命令。W40-#50 P1: TimeoutExpired 不再穿透 — 之前一次 SEC 搜索
+    超时 30s 即抛异常中断 process_stock 该股票全部剩余年份/季报。
+    超时统一返回 rc=124 (同 timeout(1) 惯例), 由调用方按失败/重试处理。"""
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd=str(PROJECT_ROOT))
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except subprocess.TimeoutExpired as e:
+        def _s(v):
+            return v.decode("utf-8", "replace").strip() if isinstance(v, bytes) else (v or "").strip()
+        err = _s(e.stderr) or f"timeout after {timeout}s"
+        if f"timeout after {timeout}s" not in err:
+            err = f"{err} (timeout after {timeout}s)"
+        return 124, _s(e.stdout), err
+
+
+def _atomic_write_text(path: Path, text: str):
+    """tmp+rename 原子写。W40-#50 P1: 之前直接 write_text, scheduler 3600s
+    超时 kill 可能落在写一半 → 截断 JSON → 下次 cron json.loads 崩溃且
+    每次在同一点崩, 队列永久卡死需人工删文件。"""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _read_json_safe(path: Path):
+    """读 JSON; 损坏 (截断/非法 JSON) 时把坏文件移 aside 保留排查并返回
+    None, 不让单个坏文件炸掉整个批次。"""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
+        corrupt = path.with_suffix(
+            path.suffix + f".corrupt-{datetime.now(TZ_CN).strftime('%Y%m%d%H%M%S')}"
+        )
+        try:
+            path.replace(corrupt)
+            log.error("State file corrupted, moved aside: %s -> %s (%s)", path, corrupt, e)
+        except OSError:
+            log.error("State file corrupted and could not be moved aside: %s (%s)", path, e)
+        return None
 
 # W36: 复用 unified_downloader.utils.adr_map, 避免跟 m_stock 重复实现.
 # 老代码 (load_adr_map / _us_key_variants / _lookup_us_map / resolve_target)
@@ -88,7 +139,9 @@ def quarterly_search_market(is_adr_hk, is_20f, mkt_key):
 
 def search_docs(code, market, rtype, limit=50):
     flag = MARKET_FLAGS[market]
-    rc, out, _ = run(["python3","-m","unified_downloader.cli","search","list",code,
+    # W40-#50 P1: sys.executable 而非裸 "python3" — 用当前解释器 (服务器
+    # /usr/bin/python3 或本地 venv), 避免子进程解析到没有依赖的另一个 python
+    rc, out, _ = run([sys.executable,"-m","unified_downloader.cli","search","list",code,
                       "-t",rtype,"-m",flag,"-l",str(limit)], timeout=30)
     docs = []
     for line in out.split("\n"):
@@ -115,7 +168,7 @@ def download_one(code, market, year, rtype, retries=3):
             delay = [10,30,60][n-1]
             log.warning("Retry %d/%d after %ds", n, retries, delay)
             time.sleep(delay)
-        cmd = ["python3", "-m", "unified_downloader.cli", "download", "single",
+        cmd = [sys.executable, "-m", "unified_downloader.cli", "download", "single",
                code, "-y", year, "-t", rtype, "-m", flag]
         # IMA现在直接支持HTML上传，不需要转PDF；图片已自动内嵌为base64
         # if market == "US":
@@ -152,10 +205,12 @@ def validate_file(fpath):
     return True
 
 def upload_ima(fpath, kb="年报季度报知识库"):
-    if not IMA_SYNC_SCRIPT.exists():
-        log.error("    IMA sync script missing: %s", IMA_SYNC_SCRIPT)
+    ima_script = _resolve_ima_script()
+    if not ima_script.exists():
+        log.error("    IMA sync script missing: %s (set IMA_SYNC_SCRIPT_PATH or put "
+                  "scripts/sync_to_ima.sh in repo)", ima_script)
         return False
-    rc, out, err = run(["bash", str(IMA_SYNC_SCRIPT), "--file", str(fpath),
+    rc, out, err = run(["bash", str(ima_script), "--file", str(fpath),
                         "--kb-name", kb, "--force"], timeout=300)
     combined = out + "\n" + err
     lower = combined.lower()
@@ -197,11 +252,14 @@ def log_failure(code, name, detail):
 # ── 状态管理 ──
 
 def load_state(code: str) -> dict:
-    """加载单只股票的状态文件"""
+    """加载单只股票的状态文件。损坏文件移 aside 后返回全新状态
+    (比之前 json.loads 直接崩、整只股票中断要好)。"""
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     f = STATE_DIR / f"{code}.json"
     if f.exists():
-        return json.loads(f.read_text())
+        st = _read_json_safe(f)
+        if st is not None:
+            return st
     return {
         "code": code, "annual": {}, "quarterly": {},
         "created_at": datetime.now(TZ_CN).isoformat(),
@@ -210,7 +268,10 @@ def load_state(code: str) -> dict:
 def save_state(state: dict):
     code = state["code"]
     state["updated_at"] = datetime.now(TZ_CN).isoformat()
-    (STATE_DIR / f"{code}.json").write_text(json.dumps(state, ensure_ascii=False, indent=2))
+    _atomic_write_text(
+        STATE_DIR / f"{code}.json",
+        json.dumps(state, ensure_ascii=False, indent=2),
+    )
 
 def set_doc_status(state: dict, category: str, year: str, quarter: str,
                    status: str, filepath=None, reason=None, fsize=None, form_type=None):

--- a/scripts/bulk_scheduler.py
+++ b/scripts/bulk_scheduler.py
@@ -28,6 +28,50 @@ STATUS_ICONS = {
 
 DEDUP_US = {"TCEHY.US", "BEKE.US", "HTHT.US"}
 PROCESSING_STALE_SECONDS = 2 * 3600
+# W40-#50 P1: failed 不再是终态 — 与 bulk_download "Failed attempts must
+# remain retryable in later cron runs" 的设计对齐。限制: 每只股票最多
+# MAX_FAILED_ATTEMPTS 次, 且两次尝试间隔 >= FAILED_RETRY_BACKOFF_SECONDS,
+# 避免坏股票每小时空转占掉整个 cron 窗口。
+MAX_FAILED_ATTEMPTS = 5
+FAILED_RETRY_BACKOFF_SECONDS = 4 * 3600
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """tmp+rename 原子写。W40-#50 P1: 之前直接 write_text, 调度器超时 kill
+    子进程可能落在写一半 → 截断 JSON → 下次 cron json.loads 崩溃且每次
+    在同一点崩, 队列永久卡死需人工删文件。"""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _read_json_safe(path: Path):
+    """读 JSON; 损坏 (截断/非法) 时移 aside 保留排查并返回 None。
+    单个坏状态文件不应炸掉整个调度循环。"""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
+        corrupt = path.with_suffix(
+            path.suffix + f".corrupt-{datetime.now(TZ_CN).strftime('%Y%m%d%H%M%S')}"
+        )
+        try:
+            path.replace(corrupt)
+            print(f"WARN: corrupted JSON moved aside: {path} -> {corrupt} ({e})")
+        except OSError:
+            print(f"WARN: corrupted JSON unreadable and could not be moved: {path} ({e})")
+        return None
+
+
+def _is_retryable_failed(stock: dict, now: datetime) -> bool:
+    """failed 股票是否可重试: 未超尝试上限 且 距上次失败已过退避窗口。"""
+    if stock.get("status") != "failed":
+        return False
+    if stock.get("attempts", 1) >= MAX_FAILED_ATTEMPTS:
+        return False
+    failed_at = _parse_iso_datetime(stock.get("failed_at"))
+    if failed_at and (now - failed_at).total_seconds() < FAILED_RETRY_BACKOFF_SECONDS:
+        return False
+    return True
 
 
 def _normalize_watchlist_rows(rows: list) -> list[tuple[str, str, str]]:
@@ -109,7 +153,7 @@ def build_queue(rows: list[tuple[str, str, str]]) -> list[dict]:
 
 def write_queue(queue: list[dict]) -> None:
     QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    QUEUE_FILE.write_text(json.dumps({
+    _atomic_write_text(QUEUE_FILE, json.dumps({
         "created_at": datetime.now(TZ_CN).isoformat(),
         "total": len(queue), "pending": len(queue), "done": 0, "failed": 0,
         "stocks": queue,
@@ -282,7 +326,7 @@ def recover_stale_processing(q: dict, max_age_seconds: int = PROCESSING_STALE_SE
         sf = _find_state(code)
         if _processing_age_seconds(stock, sf) < max_age_seconds:
             continue
-        st = json.loads(sf.read_text()) if sf and sf.exists() else None
+        st = _read_json_safe(sf) if sf and sf.exists() else None
         sm = get_state_summary(st) if st else {}
         failures = sm.get("annual_failed", 0) + sm.get("quarterly_failed", 0) + sm.get("ima_failed", 0)
         ok = sm.get("annual_ok", 0) + sm.get("quarterly_ok", 0)
@@ -309,14 +353,23 @@ def recover_stale_processing(q: dict, max_age_seconds: int = PROCESSING_STALE_SE
 
 
 def has_unfinished_queue_items(q: dict) -> bool:
-    return any(s.get("status") in {"pending", "processing"} for s in q.get("stocks", []))
+    now = datetime.now(TZ_CN)
+    for s in q.get("stocks", []):
+        if s.get("status") in {"pending", "processing"}:
+            return True
+        if _is_retryable_failed(s, now):
+            return True
+    return False
 
 def show_status():
     if not QUEUE_FILE.exists():
         print("No queue. Run --init first.")
         return
 
-    q = json.loads(QUEUE_FILE.read_text())
+    q = _read_json_safe(QUEUE_FILE)
+    if q is None:
+        print("ERROR: queue file corrupted (moved aside). Run --init to rebuild.")
+        return
     print(f"\n{'='*70}")
     print(f"  批量下载状态 — {q['total']} stocks  "
           f"✅{q['done']}  ❌{q['failed']}  ⬜{q['pending']}")
@@ -329,8 +382,12 @@ def show_status():
         # 读取细粒度状态
         sf = _find_state(code)
         detail = ""
-        if sf:
-            st = json.loads(sf.read_text())
+        if sf and sf.exists():
+            st = _read_json_safe(sf)
+            if st is None:
+                detail = " (状态文件损坏已移出)"
+                print(f"  {marker} {code:15s} {s['name']:12s} {s['market']}  {detail}")
+                continue
             sm = get_state_summary(st)
             detail = f" A:{sm.get('annual_ok',0)}/{sm.get('annual_ok',0)+sm.get('annual_skipped',0)} "
             detail += f"Q:{sm.get('quarterly_ok',0)}/{sm.get('quarterly_ok',0)+sm.get('quarterly_skipped',0)} "
@@ -359,7 +416,10 @@ def show_detail(code: str = None):
     if not sf.exists():
         print(f"No state file for {code}")
         return
-    st = json.loads(sf.read_text())
+    st = _read_json_safe(sf)
+    if st is None:
+        print(f"State file for {code} was corrupted and has been moved aside.")
+        return
     print(f"\n{'='*70}")
     print(f"  {code}  {st.get('name','?')}  market={st.get('market','?')}")
     print(f"  status={st.get('status','?')}  updated={st.get('updated_at','?')}")
@@ -396,19 +456,42 @@ def show_detail(code: str = None):
           f"IMA:{sm.get('ima_ok',0)} Failed:{sm.get('annual_failed',0)+sm.get('quarterly_failed',0)}")
 
 
+def _pick_retryable_failed(q: dict) -> int | None:
+    """W40-#50 P1: 无 pending 时挑一个可重试的 failed 股票 (未超尝试上限
+    且已过退避窗口)。之前 failed 是终态, 后续 cron 永不再碰 — 与
+    bulk_download 自己声明的 '失败必须保持可重试' 直接矛盾。"""
+    now = datetime.now(TZ_CN)
+    for i, s in enumerate(q.get("stocks", [])):
+        if _is_retryable_failed(s, now):
+            return i
+    return None
+
+
 def process_next():
     if not QUEUE_FILE.exists():
         print("ERROR: no queue. Run --init first."); sys.exit(1)
-    q = json.loads(QUEUE_FILE.read_text())
+    q = _read_json_safe(QUEUE_FILE)
+    if q is None:
+        # W40-#50 P1: 队列文件损坏 (之前截断 JSON 会让每次 cron 在同一行
+        # 崩溃)。移 aside 后明确报错退出, 需人工 --init 重建, 但不再崩溃循环。
+        print("ERROR: queue file corrupted (moved aside). Run --init to rebuild.")
+        sys.exit(1)
     recovered = recover_stale_processing(q, PROCESSING_STALE_SECONDS)
     if recovered:
-        QUEUE_FILE.write_text(json.dumps(q, ensure_ascii=False, indent=2))
+        _atomic_write_text(QUEUE_FILE, json.dumps(q, ensure_ascii=False, indent=2))
         print(f"Recovered stale processing rows: {', '.join(recovered)}")
 
     idx = next((i for i,s in enumerate(q["stocks"]) if s["status"]=="pending"), None)
     if idx is None:
+        # W40-#50 P1: failed 可重试 — pending 空了先试退避窗口外的 failed
+        idx = _pick_retryable_failed(q)
+        if idx is not None:
+            q["stocks"][idx]["status"] = "pending"
+            print(f"Retrying previously failed stock: {q['stocks'][idx]['code']}")
+    if idx is None:
         if has_unfinished_queue_items(q):
-            print("No pending stocks; waiting for active processing rows or stale recovery window.")
+            print("No pending stocks; waiting for active processing rows, stale "
+                  "recovery window, or failed-retry backoff.")
         else:
             print("All stocks processed!")
         show_status()
@@ -417,8 +500,9 @@ def process_next():
     stock = q["stocks"][idx]
     code, name, market = stock["code"], stock["name"], stock["market"]
     stock["status"] = "processing"
+    stock.pop("retry_of_failed", None)
     q["pending"] = max(0, q["pending"]-1)
-    QUEUE_FILE.write_text(json.dumps(q, ensure_ascii=False, indent=2))
+    _atomic_write_text(QUEUE_FILE, json.dumps(q, ensure_ascii=False, indent=2))
 
     mflag = {"CN":"a","HK":"h","US":"m"}.get(market,"a")
     clean_code = code.replace(".US","").replace(".SH","").replace(".SZ","").replace(".HK","")
@@ -429,7 +513,9 @@ def process_next():
     timed_out = False
     returncode = 1
     try:
-        rc = subprocess.run(["python3", str(SCRIPT), "--code", clean_code,
+        # W40-#50 P1: sys.executable 而非裸 "python3" (PATH 可能解析到
+        # 没装 click/edgartools 的另一个解释器)
+        rc = subprocess.run([sys.executable, str(SCRIPT), "--code", clean_code,
                              "--market", mflag, "--name", name,
                              "--annual-years", "10", "--quarterly-years", "5"],
                             cwd=str(PROJECT_ROOT), timeout=3600)
@@ -442,14 +528,15 @@ def process_next():
     # 同步状态文件
     sf = _find_state(code)
     st = None
-    if sf:
-        st = json.loads(sf.read_text())
+    if sf and sf.exists():
+        st = _read_json_safe(sf)
+    if st is not None:
         if timed_out:
             st["interrupted"] = {
                 "reason": "scheduler timeout",
                 "at": datetime.now(TZ_CN).isoformat(),
             }
-            sf.write_text(json.dumps(st, ensure_ascii=False, indent=2))
+            _atomic_write_text(sf, json.dumps(st, ensure_ascii=False, indent=2))
         sm = get_state_summary(st)
         stock["annual_ok"] = sm.get("annual_ok",0)
         stock["quarterly_ok"] = sm.get("quarterly_ok",0)
@@ -460,18 +547,21 @@ def process_next():
         stock["status"] = "done"; q["done"] += 1
     else:
         stock["status"] = "failed"; q["failed"] += 1
+        stock["attempts"] = stock.get("attempts", 0) + 1
+        stock["failed_at"] = datetime.now(TZ_CN).isoformat()
         if timed_out:
             stock["failure_reason"] = "timeout"
 
     stock["updated_at"] = datetime.now(TZ_CN).isoformat()
     q["last_updated"] = datetime.now(TZ_CN).isoformat()
-    QUEUE_FILE.write_text(json.dumps(q, ensure_ascii=False, indent=2))
+    reconcile_queue_counts(q)
+    _atomic_write_text(QUEUE_FILE, json.dumps(q, ensure_ascii=False, indent=2))
 
-    print(f"\n{stock['status']} {code} | A:{stock['annual_ok']} Q:{stock['quarterly_ok']} F:{stock['failures']}")
+    print(f"\n{stock['status']} {code} | "
+          f"A:{stock.get('annual_ok', 0)} Q:{stock.get('quarterly_ok', 0)} "
+          f"F:{stock.get('failures', 0)}")
     if stock.get("summary_text"):
         print(stock["summary_text"])
-    reconcile_queue_counts(q)
-    QUEUE_FILE.write_text(json.dumps(q, ensure_ascii=False, indent=2))
     if not has_unfinished_queue_items(q):
         print("All stocks processed!")
         show_status()

--- a/scripts/fix_us_html_ima.py
+++ b/scripts/fix_us_html_ima.py
@@ -120,8 +120,10 @@ def convert_local_html(old_file: str) -> Path | None:
 
 
 def download_pdf(code: str, year: str, form_type: str) -> Path | None:
+    # W40-#50 P1: sys.executable 而非裸 "python3" (避免 PATH 解析到
+    # 没装依赖的另一个解释器)
     cmd = [
-        "python3", "-m", "unified_downloader.cli", "download", "single",
+        sys.executable, "-m", "unified_downloader.cli", "download", "single",
         code, "-y", year, "-t", form_type, "-m", "m", "--pdf", "--no-cache",
     ]
     rc, out, err = run(cmd, timeout=240)

--- a/tests/test_bulk_download_us_quarterly.py
+++ b/tests/test_bulk_download_us_quarterly.py
@@ -160,4 +160,4 @@ def test_ima_sync_script_path_can_be_overridden(monkeypatch):
     monkeypatch.setenv("IMA_SYNC_SCRIPT_PATH", "/tmp/custom-sync-to-ima.sh")
     bulk = load_bulk_module()
 
-    assert str(bulk.IMA_SYNC_SCRIPT) == "/tmp/custom-sync-to-ima.sh"
+    assert str(bulk._resolve_ima_script()) == "/tmp/custom-sync-to-ima.sh"

--- a/tests/test_bulk_orchestration_reliability.py
+++ b/tests/test_bulk_orchestration_reliability.py
@@ -1,0 +1,325 @@
+"""
+Regression tests for bulk 链路编排可靠性 (W40-#50 P1-编排批次).
+
+覆盖四个生产 cron 场景缺陷 + python3 硬编码:
+1. run() 超时隔离: TimeoutExpired 之前穿透炸掉整只股票
+2. scheduler failed 可重试: 之前 failed 是终态, cron 永不再碰
+3. 状态/队列 JSON 原子写 + 损坏容错: 之前超时 kill 写一半 → 截断 JSON →
+   每次 cron 在同一行崩溃, 队列永久卡死
+4. IMA 脚本查找链: 之前硬编码仓库外 ~/.openclaw 路径, 新机器部署即全量失败
+5. sys.executable 替代裸 "python3"
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str):
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace(".py", "_under_test"), path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    if hasattr(module, "log"):
+        module.log = logging.getLogger(f"test-{name}")
+    return module
+
+
+# ═══ bulk_download.run() 超时隔离 ═══
+
+
+def test_run_returns_124_on_timeout_instead_of_raising(monkeypatch):
+    """TimeoutExpired 必须被吞掉并转为 rc=124, 不能炸调用方"""
+    bulk = load_script("bulk_download.py")
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="x", timeout=30, output=b"partial out",
+                                        stderr=b"boom")
+
+    monkeypatch.setattr(bulk.subprocess, "run", fake_run)
+
+    rc, out, err = bulk.run(["echo", "hi"], timeout=30)
+
+    assert rc == 124
+    assert "partial out" in out          # bytes 输出正确解码
+    assert "boom" in err and "timeout after 30s" in err
+
+
+def test_run_timeout_with_none_output(monkeypatch):
+    """TimeoutExpired stdout/stderr 为 None 时不崩"""
+    bulk = load_script("bulk_download.py")
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="x", timeout=10)
+
+    monkeypatch.setattr(bulk.subprocess, "run", fake_run)
+
+    rc, out, err = bulk.run(["echo"], timeout=10)
+    assert rc == 124
+    assert out == ""
+    assert "timeout after 10s" in err
+
+
+def test_download_one_timeout_counts_as_failure(monkeypatch, tmp_path):
+    """全程超时的下载按 (None, "failed") 处理并重试满, 不抛异常"""
+    bulk = load_script("bulk_download.py")
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+    sleeps = []
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="x", timeout=kwargs.get("timeout", 120))
+
+    monkeypatch.setattr(bulk.subprocess, "run", fake_run)
+    monkeypatch.setattr(bulk.time, "sleep", lambda s: sleeps.append(s))
+
+    result = bulk.download_one("AAPL", "US", "2026", "10k", retries=3)
+
+    assert result == (None, "failed")
+    assert len(sleeps) == 3
+
+
+def test_search_docs_timeout_returns_empty(monkeypatch, tmp_path):
+    """搜索超时返回空列表 (走 not-in-search 路径), 不炸整只股票"""
+    bulk = load_script("bulk_download.py")
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="x", timeout=kwargs.get("timeout", 120))
+
+    monkeypatch.setattr(bulk.subprocess, "run", fake_run)
+
+    assert bulk.search_docs("AAPL", "US", "10k") == []
+
+
+# ═══ bulk_download 状态文件原子写 + 损坏容错 ═══
+
+
+def test_load_state_moves_corrupt_file_aside_and_starts_fresh(monkeypatch, tmp_path):
+    bulk = load_script("bulk_download.py")
+    state_dir = tmp_path / "bulk_state"
+    state_dir.mkdir()
+    monkeypatch.setattr(bulk, "STATE_DIR", state_dir)
+    (state_dir / "AAPL.json").write_text('{"code": "AAPL", "annu', encoding="utf-8")  # 截断
+
+    state = bulk.load_state("AAPL")
+
+    assert state["code"] == "AAPL"
+    assert state["annual"] == {} and state["quarterly"] == {}
+    # 坏文件被移 aside, 原位置不再是损坏 JSON
+    assert not (state_dir / "AAPL.json").exists() or bulk._read_json_safe(state_dir / "AAPL.json") is None
+    aside = list(state_dir.glob("AAPL.json.corrupt-*"))
+    assert len(aside) == 1, "损坏文件应保留为 .corrupt-* 以便排查"
+
+
+def test_save_state_atomic_roundtrip_no_tmp_leftover(monkeypatch, tmp_path):
+    bulk = load_script("bulk_download.py")
+    state_dir = tmp_path / "bulk_state"
+    state_dir.mkdir()
+    monkeypatch.setattr(bulk, "STATE_DIR", state_dir)
+
+    state = {"code": "AAPL", "annual": {"2026": {"status": "uploaded"}}}
+    bulk.save_state(state)
+
+    # 内容可完整读回
+    saved = json.loads((state_dir / "AAPL.json").read_text(encoding="utf-8"))
+    assert saved["annual"]["2026"]["status"] == "uploaded"
+    # 不留 .tmp 残留
+    assert list(state_dir.glob("*.tmp")) == []
+
+
+# ═══ IMA 脚本查找链 ═══
+
+
+def test_ima_script_env_override_wins(monkeypatch):
+    bulk = load_script("bulk_download.py")
+    monkeypatch.setenv("IMA_SYNC_SCRIPT_PATH", "/tmp/custom-sync.sh")
+    assert str(bulk._resolve_ima_script()) == "/tmp/custom-sync.sh"
+
+
+def test_ima_script_prefers_repo_copy_over_legacy(monkeypatch, tmp_path):
+    """仓库内有 scripts/sync_to_ima.sh 时优先于 ~/.openclaw 旧路径"""
+    bulk = load_script("bulk_download.py")
+    monkeypatch.delenv("IMA_SYNC_SCRIPT_PATH", raising=False)
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "sync_to_ima.sh").write_text("#!/bin/bash\n")
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", repo)
+
+    assert bulk._resolve_ima_script() == repo / "scripts" / "sync_to_ima.sh"
+
+
+def test_ima_script_falls_back_to_legacy_openclaw_path(monkeypatch, tmp_path):
+    """仓库内没有时回落到旧 ~/.openclaw 路径 (服务器兼容)"""
+    bulk = load_script("bulk_download.py")
+    monkeypatch.delenv("IMA_SYNC_SCRIPT_PATH", raising=False)
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)  # 无 scripts/sync_to_ima.sh
+
+    assert bulk._resolve_ima_script() == bulk.LEGACY_IMA_SYNC_SCRIPT
+
+
+def test_subprocess_cmds_use_current_interpreter(monkeypatch, tmp_path):
+    """search/download 命令用 sys.executable 而非裸 "python3" """
+    bulk = load_script("bulk_download.py")
+    monkeypatch.setattr(bulk, "PROJECT_ROOT", tmp_path)
+    cmds = []
+
+    def fake_run(cmd, timeout=120):
+        cmds.append(cmd)
+        return 1, "not found", ""
+
+    monkeypatch.setattr(bulk, "run", fake_run)
+
+    bulk.search_docs("AAPL", "US", "10k")
+    bulk.download_one("AAPL", "US", "2026", "10k", retries=0)
+
+    assert all(c[0] == bulk.sys.executable for c in cmds)
+    assert not any(c[0] == "python3" for c in cmds)
+
+
+# ═══ scheduler: failed 可重试 ═══
+
+
+def _scheduler():
+    return load_script("bulk_scheduler.py")
+
+
+def test_failed_stock_is_retryable_after_backoff():
+    sched = _scheduler()
+    old = (datetime.now(sched.TZ_CN) - timedelta(hours=5)).isoformat()
+    stock = {"status": "failed", "attempts": 1, "failed_at": old}
+
+    assert sched._is_retryable_failed(stock, datetime.now(sched.TZ_CN)) is True
+
+
+def test_failed_stock_blocked_during_backoff_window():
+    sched = _scheduler()
+    fresh = (datetime.now(sched.TZ_CN) - timedelta(minutes=30)).isoformat()
+    stock = {"status": "failed", "attempts": 1, "failed_at": fresh}
+
+    assert sched._is_retryable_failed(stock, datetime.now(sched.TZ_CN)) is False
+
+
+def test_failed_stock_capped_after_max_attempts():
+    sched = _scheduler()
+    old = (datetime.now(sched.TZ_CN) - timedelta(days=3)).isoformat()
+    stock = {"status": "failed", "attempts": sched.MAX_FAILED_ATTEMPTS, "failed_at": old}
+
+    assert sched._is_retryable_failed(stock, datetime.now(sched.TZ_CN)) is False
+
+
+def test_pick_retryable_failed_skips_backoff_and_cap():
+    sched = _scheduler()
+    now = datetime.now(sched.TZ_CN)
+    q = {"stocks": [
+        {"code": "FRESH", "status": "failed", "attempts": 1,
+         "failed_at": (now - timedelta(minutes=10)).isoformat()},        # 退避中
+        {"code": "CAPPED", "status": "failed", "attempts": 99,
+         "failed_at": (now - timedelta(days=1)).isoformat()},            # 超上限
+        {"code": "OK", "status": "failed", "attempts": 1,
+         "failed_at": (now - timedelta(hours=5)).isoformat()},           # 可重试
+    ]}
+
+    idx = sched._pick_retryable_failed(q)
+    assert idx == 2
+
+
+def test_has_unfinished_considers_retryable_failed():
+    sched = _scheduler()
+    retryable = {"status": "failed", "attempts": 1,
+                 "failed_at": (datetime.now(sched.TZ_CN) - timedelta(hours=5)).isoformat()}
+    exhausted = {"status": "failed", "attempts": sched.MAX_FAILED_ATTEMPTS,
+                 "failed_at": (datetime.now(sched.TZ_CN) - timedelta(days=3)).isoformat()}
+
+    assert sched.has_unfinished_queue_items({"stocks": [retryable]}) is True
+    assert sched.has_unfinished_queue_items({"stocks": [exhausted]}) is False
+
+
+def test_process_next_retries_failed_stock_when_no_pending(tmp_path, monkeypatch, capsys):
+    """pending 空了要挑退避窗口外的 failed 重试, 且失败后 attempts 递增"""
+    sched = _scheduler()
+    queue_file = tmp_path / "queue.json"
+    queue_file.write_text(json.dumps({
+        "total": 1, "done": 0, "failed": 1, "pending": 0,
+        "stocks": [{
+            "code": "AAPL.US", "name": "Apple", "market": "US", "status": "failed",
+            "attempts": 1,
+            "failed_at": (datetime.now(sched.TZ_CN) - timedelta(hours=5)).isoformat(),
+        }],
+    }, ensure_ascii=False), encoding="utf-8")
+    monkeypatch.setattr(sched, "QUEUE_FILE", queue_file)
+    monkeypatch.setattr(sched, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(sched, "FAIL_LOG", tmp_path / "failures.log")
+
+    class Result:
+        returncode = 1  # 再次失败
+
+    monkeypatch.setattr(sched.subprocess, "run", lambda *a, **k: Result())
+
+    sched.process_next()
+
+    out = capsys.readouterr().out
+    assert "Retrying previously failed stock: AAPL.US" in out
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    stock = payload["stocks"][0]
+    assert stock["status"] == "failed"
+    assert stock["attempts"] == 2
+    assert stock["failed_at"]
+
+
+# ═══ scheduler: 队列/状态损坏容错 ═══
+
+
+def test_process_next_corrupt_queue_exits_cleanly_not_crash_loop(tmp_path, monkeypatch, capsys):
+    """截断的队列 JSON: 移 aside + 明确报错退出, 不再每次 cron 同点崩溃"""
+    sched = _scheduler()
+    queue_file = tmp_path / "queue.json"
+    queue_file.write_text('{"total": 3, "stocks": [{"code": "AA', encoding="utf-8")
+    monkeypatch.setattr(sched, "QUEUE_FILE", queue_file)
+    monkeypatch.setattr(sched, "STATE_DIR", tmp_path / "state")
+
+    import pytest
+    with pytest.raises(SystemExit):
+        sched.process_next()
+
+    assert "corrupted" in capsys.readouterr().out
+    assert not queue_file.exists()
+    assert len(list(tmp_path.glob("queue.json.corrupt-*"))) == 1
+
+
+def test_recover_stale_processing_tolerates_corrupt_state_file(tmp_path, monkeypatch):
+    """恢复 stale processing 时状态文件损坏 → 按空状态处理, 不崩调度器"""
+    sched = _scheduler()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "ASML.json").write_text('{"annual": {"20', encoding="utf-8")  # 截断
+    monkeypatch.setattr(sched, "STATE_DIR", state_dir)
+    q = {"stocks": [{
+        "code": "ASML.US", "name": "ASML", "market": "US", "status": "processing",
+        "updated_at": (datetime.now(sched.TZ_CN) - timedelta(hours=3)).isoformat(),
+    }]}
+
+    recovered = sched.recover_stale_processing(q, max_age_seconds=0)
+
+    assert recovered == ["ASML.US"]
+    assert q["stocks"][0]["status"] == "pending"
+    assert q["stocks"][0]["recovery_reason"] == "empty_or_missing_state_retry"
+
+
+def test_scheduler_queue_write_is_atomic_no_tmp_leftover(tmp_path, monkeypatch):
+    sched = _scheduler()
+    queue_file = tmp_path / "queue.json"
+    monkeypatch.setattr(sched, "QUEUE_FILE", queue_file)
+
+    sched.write_queue([{"code": "AAPL.US", "name": "Apple", "market": "US"}])
+
+    payload = json.loads(queue_file.read_text(encoding="utf-8"))
+    assert payload["total"] == 1
+    assert list(tmp_path.glob("*.tmp")) == []


### PR DESCRIPTION
## 背景

#50 P1-编排批次：服务器 cron 场景下四个相互放大的缺陷。之前一条失败链是：单次超时炸整只股票 → 退出码语义错 → scheduler 标 failed（终态）→ 永不重试；同时状态文件非原子写 + 超时 kill 会造成截断 JSON → 下次 cron 在同一行崩溃 → 队列永久卡死。

## 修复内容

### 1. `run()` 超时隔离（`bulk_download.py`）
`TimeoutExpired` 之前直接穿透 `process_stock` → 该股票剩余所有年份/季报全部不处理。现在 `run()` 捕获并统一返回 `rc=124`（timeout(1) 惯例），由调用方按既有失败/重试路径处理：`download_one` 重试耗尽记 `(None, "failed")`（衔接 PR #51 的三态契约）、`search_docs` 返回空走 not-in-search 路径、`upload_ima` 记 ima_failed。

### 2. failed 可重试（`bulk_scheduler.py`）
- 之前：scheduler 只取 pending、只回收 stale processing，`failed` 是终态——与 `bulk_download` 自己注释的 *"Failed attempts must remain retryable in later cron runs"* 直接矛盾
- 现在：无 pending 时挑可重试的 failed（距上次失败 ≥ 4h 退避窗口，且尝试 < 5 次上限）；`has_unfinished_queue_items` 同步识别可重试 failed；标记失败时记录 `attempts`/`failed_at`

### 3. 原子写 + 损坏容错（两脚本）
- 所有 JSON 写入改 tmp+rename（`os.replace`）原子写——超时 kill 不再留下截断文件
- 所有读取走 `_read_json_safe`：损坏文件移 aside 为 `.corrupt-{时间戳}`（保留排查）后按空状态处理或明确报错退出——单文件损坏不再让每次 cron 在同一行崩溃
- 附带：`process_next` 尾部两次重复队列写入合并为一次；`stock['annual_ok'\] KeyError 防御（老队列文件缺字段）

### 4. IMA 脚本查找链（`bulk_download.py`）
之前默认硬编码仓库外 `~/.openclaw/workspace/skills/unified-downloader/scripts/sync_to_ima.sh`（不在版本控制，新机器不存在 → 所有上传失败、全队列 failed）。现在：`IMA_SYNC_SCRIPT_PATH` 环境变量 → 仓库内 `scripts/sync_to_ima.sh`（标准位置）→ 旧路径 fallback（服务器兼容）。

> ⚠️ 后续动作（#50 待办）：需把服务器上真实的 `sync_to_ima.sh` 拷进仓库一次，查找链才会命中仓库内路径。

### 5. `python3` → `sys.executable`（3 处）
服务器上 morning-brief 用 `/usr/bin/python3` 启动时，子进程裸 `python3` 取自 PATH，可能解析到没装 click/edgartools 的解释器。

## 测试

新增 `test_bulk_orchestration_reliability.py` **19 用例**（超时三场景、原子写/损坏容错、查找链三分支、failed 重试矩阵、process_next 级集成、解释器断言）；全量 **184 passed**。

Refs #50（P1-编排四项勾选）