### PR TITLE
fix(P1): 并发正确性 / infra 接线 — 熔断器、断点续传 MD5、缓存、异步链路、429

### DIFF
--- a/tests/test_p1_concurrency_infra.py
+++ b/tests/test_p1_concurrency_infra.py
@@ -1,0 +1,456 @@
+"""
+Regression tests for P1-并发/infra 批次 (W40-#50).
+
+覆盖:
+1. 断点续传 MD5: 增量哈希 → 全文件校验 (之前续传 + expected_md5 100% 校验
+   失败并删除整个完整文件)
+2. 熔断器线程安全 + config 接线 + half_open 预算生效
+3. adapter 标志恢复 (之前一次 --pdf 永久污染共享 adapter)
+4. 缓存写失败不连坐市场失败 / 不误开熔断
+5. checkpoint 原子写 + 损坏容错 (之前毒化该 task 全部后续下载)
+6. 缓存 LRU 超限清理 (之前单日写超 max_size 时清理完全失效)
+7. 429 重试: Retry-After 解析 / 末次不白睡 / 异步版对齐重试
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from unified_downloader.infra.http_client import (
+    HTTPClient,
+    AsyncHTTPClient,
+    _parse_retry_after,
+    _md5_of_file,
+)
+from unified_downloader.infra.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerManager,
+)
+from unified_downloader.infra.checkpoint import CheckpointManager
+from unified_downloader.infra.cache import CacheManager
+
+
+# ═══ Retry-After 解析 ═══
+
+
+class TestParseRetryAfter:
+    def test_numeric_seconds(self):
+        assert _parse_retry_after("30") == 30
+
+    def test_http_date_falls_back_to_default(self):
+        # W40-#50: 之前裸 int() 遇 HTTP-date 抛 ValueError
+        assert _parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") == 60
+
+    def test_none_and_garbage(self):
+        assert _parse_retry_after(None) == 60
+        assert _parse_retry_after("soon") == 60
+        assert _parse_retry_after("5", default=10) == 5
+
+
+# ═══ 断点续传 MD5 全文件校验 ═══
+
+
+class _FakeResponse:
+    def __init__(self, status_code, chunks, headers=None):
+        self.status_code = status_code
+        self._chunks = chunks
+        self.headers = headers or {}
+
+    def iter_content(self, chunk_size=8192):
+        yield from self._chunks
+
+    def raise_for_status(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class TestMd5Resume:
+    def test_md5_of_file_matches_hashlib(self, tmp_path):
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"0123456789")
+        assert _md5_of_file(f) == hashlib.md5(b"0123456789").hexdigest()
+
+    def test_resume_with_expected_md5_verifies_full_file(self, tmp_path, monkeypatch):
+        """续传 6 字节前缀 + 4 字节增量, expected_md5 是全 10 字节的哈希 —
+        之前增量哈希必不相等 → 删整个文件; 现在校验通过"""
+        client = HTTPClient()
+        target = tmp_path / "out.bin"
+        prefix, rest = b"012345", b"6789"
+        target.write_bytes(prefix)  # 已下载前缀
+
+        fake_session = MagicMock()
+        fake_session.request.return_value = _FakeResponse(206, [rest])
+        monkeypatch.setattr(client, "_session", fake_session)
+
+        result = client.download_file(
+            url="https://example.com/f.bin",
+            file_path=target,
+            checkpoint={"downloaded_bytes": len(prefix)},
+            expected_md5=hashlib.md5(prefix + rest).hexdigest(),
+        )
+
+        assert result["file_size"] == 10
+        assert target.read_bytes() == prefix + rest  # 文件完好, 没被删
+
+    def test_fresh_download_corrupt_md5_still_deletes(self, tmp_path, monkeypatch):
+        """非续传路径的完整性校验语义保持: 内容不符仍删文件"""
+        client = HTTPClient()
+        target = tmp_path / "out.bin"
+
+        fake_session = MagicMock()
+        fake_session.request.return_value = _FakeResponse(200, [b"wrong-content"])
+        monkeypatch.setattr(client, "_session", fake_session)
+
+        from unified_downloader.exceptions import FileIntegrityError
+
+        with pytest.raises(FileIntegrityError):
+            client.download_file(
+                url="https://example.com/f.bin",
+                file_path=target,
+                expected_md5=hashlib.md5(b"expected").hexdigest(),
+            )
+        assert not target.exists()
+
+
+# ═══ 熔断器 ═══
+
+
+class TestCircuitBreaker:
+    def test_config_wired_through_manager(self):
+        cfg = CircuitBreakerConfig(failure_threshold=10)
+        manager = CircuitBreakerManager(default_config=cfg)
+        # W40-#50: 之前 YAML 熔断配置被静默丢弃, 实际永远是默认 5
+        assert manager.get_breaker("m").config.failure_threshold == 10
+
+    def test_half_open_probe_budget_enforced(self):
+        """半开状态最多放 half_open_max_calls 个试探请求"""
+        from datetime import datetime, timedelta
+
+        breaker = CircuitBreaker("m", CircuitBreakerConfig(
+            failure_threshold=2, timeout=10, half_open_max_calls=3))
+        breaker.record_failure()
+        breaker.record_failure()
+        assert breaker.is_open
+
+        # 时间旅行跳过熔断冷却窗口 → 进入半开
+        breaker._last_failure_time = datetime.now() - timedelta(seconds=20)
+        assert breaker.is_half_open
+
+        assert breaker.can_execute() is True   # 试探 1
+        assert breaker.can_execute() is True   # 试探 2
+        assert breaker.can_execute() is True   # 试探 3
+        assert breaker.can_execute() is False  # 超出预算 — 之前无人调用此门控
+
+    def test_concurrent_failures_open_breaker(self):
+        """线程池并发打失败不再丢计数 (1000 次失败, 阈值 5, 必须开)"""
+        breaker = CircuitBreaker("m", CircuitBreakerConfig(failure_threshold=5))
+
+        def hammer():
+            for _ in range(100):
+                breaker.record_failure()
+
+        threads = [threading.Thread(target=hammer) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert breaker.is_open
+
+    def test_concurrent_mixed_calls_no_corruption(self):
+        breaker = CircuitBreaker("m", CircuitBreakerConfig(failure_threshold=100))
+
+        def succeeder():
+            for _ in range(200):
+                breaker.record_success()
+
+        def failer():
+            for _ in range(200):
+                breaker.record_failure()
+
+        threads = [
+            threading.Thread(target=succeeder) for _ in range(5)
+        ] + [threading.Thread(target=failer) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        status = breaker.get_status()
+        assert 0 <= status["failure_count"] <= 1000  # 未 corrupt
+
+
+# ═══ checkpoint ═══
+
+
+class TestCheckpoint:
+    def test_corrupt_checkpoint_returns_none_not_raise(self, tmp_path):
+        mgr = CheckpointManager(tmp_path)
+        cp = tmp_path / "task.json"
+        cp.write_text('{"task_id": "task", "url', encoding="utf-8")  # 截断
+
+        # W40-#50: 之前抛 CheckpointError 毒化该 task_id 的全部后续下载
+        assert mgr.get("task") is None
+        assert not cp.exists()  # 坏文件已清理
+
+    def test_save_is_atomic_and_roundtrips(self, tmp_path):
+        mgr = CheckpointManager(tmp_path)
+        mgr.save("t1", "https://x", "/tmp/f", 100)
+
+        data = mgr.get("t1")
+        assert data["downloaded_bytes"] == 100
+        assert list(tmp_path.glob("*.tmp")) == []  # 无残留 tmp
+
+
+# ═══ 缓存 LRU 清理 ═══
+
+
+class TestCacheLruCleanup:
+    def test_same_day_overflow_evicts_lru(self, tmp_path):
+        """单日写超 max_size 时按 last_access 淘汰 (之前 7 天清理删不掉任何
+        今天创建的条目, 缓存无限增长)"""
+        # 3 × 10KB = 30KB, 上限 ~21KB → 需淘汰 1 个
+        mgr = CacheManager(tmp_path, ttl_days=30, max_size_gb=0.00002)
+        payload = b"x" * 10240
+
+        fa = tmp_path / "a.pdf"; fa.write_bytes(payload)
+        fb = tmp_path / "b.pdf"; fb.write_bytes(payload)
+        fc = tmp_path / "c.pdf"; fc.write_bytes(payload)
+
+        mgr.put("m", "AAA", 2025, "10k", fa)
+        mgr.put("m", "BBB", 2025, "10k", fb)
+        # 访问 A → A 的 last_access 最新, B 变最旧
+        mgr.get("m", "AAA", 2025, "10k")
+        mgr.put("m", "CCC", 2025, "10k", fc)  # 触发超限清理
+
+        assert mgr.get("m", "AAA", 2025, "10k") is not None  # 最新访问保留
+        assert mgr.get("m", "CCC", 2025, "10k") is not None
+        assert mgr.get("m", "BBB", 2025, "10k") is None      # 最久未用被淘汰
+        assert mgr.get_size() <= mgr._max_size_bytes
+
+
+# ═══ UnifiedDownloader: 标志恢复 / 缓存隔离 / config 接线 ═══
+
+
+@pytest.fixture
+def downloader(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # config/cache/audit 目录全落 tmp
+    from unified_downloader.core.downloader import UnifiedDownloader
+    from unified_downloader.core.config import get_default_config
+
+    d = UnifiedDownloader(get_default_config())
+    yield d
+    d.close()
+
+
+def _mock_adapter_success(d, tmp_path):
+    from unified_downloader.models.enums import Market
+    from unified_downloader.models.entities import DownloadResult
+
+    out = tmp_path / "downloads" / "m" / "AAP" / "AAPL_2026_10K.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(b"<html>" + b"y" * 2048 + b"</html>")
+
+    adapter = d._adapters[Market.M]
+    result = DownloadResult(
+        success=True, file_path=str(out), file_size=out.stat().st_size, source="edgar"
+    )
+    adapter.download = MagicMock(return_value=result)
+    return adapter, result
+
+
+class TestDownloaderP1:
+    def test_breaker_config_from_config_yaml(self, downloader):
+        # W40-#50: manager 拿到 config.circuit_breaker (之前被丢弃)
+        breaker = downloader._circuit_breaker_manager.get_breaker("m")
+        assert breaker.config is downloader.config.circuit_breaker
+
+    def test_convert_to_pdf_flag_restored_after_call(self, downloader, tmp_path):
+        adapter, _ = _mock_adapter_success(downloader, tmp_path)
+        assert adapter._convert_to_pdf is False
+
+        downloader.download("AAPL", 2026, "10k", convert_to_pdf=True)
+
+        # W40-#50: 之前一次 True 永久污染, 后续所有调用也转 PDF
+        assert adapter._convert_to_pdf is False
+
+    def test_translate_flag_restored_after_call(self, downloader, tmp_path):
+        adapter, _ = _mock_adapter_success(downloader, tmp_path)
+
+        downloader.download("AAPL", 2026, "10k", translate=True)
+
+        assert adapter._translate_enabled is False  # 恢复原值
+
+    def test_use_cache_flag_restored_after_call(self, downloader, tmp_path):
+        adapter, _ = _mock_adapter_success(downloader, tmp_path)
+        adapter._use_translate_cache = True
+
+        downloader.download("AAPL", 2026, "10k", use_cache=False)
+
+        assert adapter._use_translate_cache is True  # 恢复, 不再永久禁用
+
+    def test_cache_write_failure_does_not_fail_download(
+        self, downloader, tmp_path, monkeypatch
+    ):
+        from unified_downloader.exceptions import CacheError
+
+        _mock_adapter_success(downloader, tmp_path)
+        monkeypatch.setattr(
+            downloader._cache_manager, "put",
+            MagicMock(side_effect=CacheError("database is locked")),
+        )
+
+        result = downloader.download("AAPL", 2026, "10k")
+
+        # W40-#50: 之前穿透到 except → UNEXPECTED_ERROR + record_failure,
+        # 连续 5 次误开熔断; 文件其实已完整落盘
+        assert result.success is True
+        assert not result.error_code
+        breaker = downloader._circuit_breaker_manager.get_breaker("m")
+        assert breaker.is_closed is True  # 缓存故障没有计入熔断
+
+    def test_checkpoint_resume_failure_tolerated(self, downloader, tmp_path, monkeypatch):
+        from unified_downloader.exceptions import CheckpointError
+
+        _mock_adapter_success(downloader, tmp_path)
+        monkeypatch.setattr(
+            downloader._checkpoint_manager, "resume",
+            MagicMock(side_effect=CheckpointError("boom")),
+        )
+
+        result = downloader.download("AAPL", 2026, "10k")
+
+        # W40-#50: 之前该 task_id 的每一次下载都直接抛 CheckpointError
+        assert result.success is True
+
+
+# ═══ 异步: config 统一 / 熔断+缓存接线 / 429 重试 ═══
+
+
+class TestAsyncDownloaderP1:
+    def test_single_config_instance(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+
+        ad = AsyncUnifiedDownloader()
+        # W40-#50: 之前 self.config (裸 Config) 与内部 downloader 的
+        # get_default_config() 是两个实例
+        assert ad.config is ad._downloader.config
+
+    def test_success_writes_cache_and_breaker(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+        from unified_downloader.models.enums import Market
+        from unified_downloader.models.entities import DownloadResult
+
+        ad = AsyncUnifiedDownloader()
+        out = tmp_path / "dl.html"
+        out.write_bytes(b"<html>" + b"z" * 1024 + b"</html>")
+        result = DownloadResult(success=True, file_path=str(out), file_size=2048)
+
+        adapter = ad._downloader._adapters[Market.M]
+        adapter.async_download = AsyncMock(return_value=result)
+        put_mock = MagicMock()
+        monkeypatch.setattr(ad._downloader._cache_manager, "put", put_mock)
+
+        r = asyncio.run(
+            ad.download("AAPL", 2026, "10k", market=Market.M, use_cache=True)
+        )
+
+        assert r.success is True
+        put_mock.assert_called_once()  # W40-#50: 之前异步成果永远不进缓存
+
+    def test_breaker_open_short_circuits_async(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+        from unified_downloader.models.enums import Market
+
+        ad = AsyncUnifiedDownloader()
+        breaker = ad._downloader._circuit_breaker_manager.get_breaker("m")
+        cfg = breaker.config
+        for _ in range(cfg.failure_threshold):
+            breaker.record_failure()
+
+        adapter = ad._downloader._adapters[Market.M]
+        adapter.async_download = AsyncMock()
+
+        r = asyncio.run(ad.download("AAPL", 2026, "10k", market=Market.M))
+
+        assert r.success is False
+        assert r.error_code == "CIRCUIT_BREAKER_OPEN"
+        adapter.async_download.assert_not_awaited()  # W40-#50: 之前完全绕过
+
+
+class _FakeAsyncCtx:
+    def __init__(self, status, headers=None):
+        self.status = status
+        self.headers = headers or {}
+        self.content_type = "application/octet-stream"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    async def read(self):
+        return b"body"
+
+
+class _FakeAsyncSession:
+    def __init__(self, statuses):
+        self._statuses = statuses
+        self.calls = 0
+
+    def request(self, method, url, **kwargs):
+        status = self._statuses[min(self.calls, len(self._statuses) - 1)]
+        self.calls += 1
+        return _FakeAsyncCtx(status, headers={"Retry-After": "0"})
+
+
+class TestAsync429Retry:
+    def _patch_session(self, client, fake, monkeypatch):
+        async def fake_prop(self):
+            await asyncio.sleep(0)
+            return fake
+
+        monkeypatch.setattr(type(client), "session", property(fake_prop))
+
+    def test_429_retries_then_succeeds(self, monkeypatch):
+        """W40-#50: 异步版之前第一次 429 就抛 RateLimitError, 完全不重试"""
+        from unified_downloader.exceptions import RateLimitError
+
+        client = AsyncHTTPClient(max_retries=3)
+        fake = _FakeAsyncSession([429, 200])
+        self._patch_session(client, fake, monkeypatch)
+
+        result = asyncio.run(client._request("GET", "https://example.com"))
+
+        assert fake.calls == 2
+        assert result["status"] == 200
+
+    def test_429_exhausted_raises_without_sleeping_on_last(self, monkeypatch):
+        from unified_downloader.exceptions import RateLimitError
+
+        client = AsyncHTTPClient(max_retries=2)
+        fake = _FakeAsyncSession([429, 429])
+        self._patch_session(client, fake, monkeypatch)
+        sleeps = []
+        monkeypatch.setattr(client, "_sleep", AsyncMock(side_effect=lambda s: sleeps.append(s)))
+
+        with pytest.raises(RateLimitError):
+            asyncio.run(client._request("GET", "https://example.com"))
+
+        assert fake.calls == 2
+        assert len(sleeps) == 1  # 末次尝试不白睡

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -1535,7 +1535,10 @@ class MStockAdapter(BaseStockAdapter):
                 and downloaded_path.suffix.lower() in (".html", ".htm")
             ):
                 try:
-                    pdf_path = HTMLToPDFConverter.convert(
+                    # W40-#50 P1: weasyprint 是重 CPU 同步调用, 之前直接在
+                    # 协程里跑会冻结整个事件循环 (其余并发下载全部停摆)
+                    pdf_path = await asyncio.to_thread(
+                        HTMLToPDFConverter.convert,
                         downloaded_path,
                         keep_original=self._keep_original_html,
                     )
@@ -1554,7 +1557,10 @@ class MStockAdapter(BaseStockAdapter):
                 and downloaded_path.suffix.lower() == ".pdf"
             ):
                 try:
-                    translated_path = PDFTranslator.translate(
+                    # W40-#50 P1: 翻译内部是 subprocess.run(timeout=1800) 的
+                    # 同步阻塞调用, 之前直接在协程里跑最长冻结事件循环 30 分钟
+                    translated_path = await asyncio.to_thread(
+                        PDFTranslator.translate,
                         downloaded_path,
                         api_key=self._translate_api_key,
                         model=self._translate_model,

--- a/unified_downloader/core/async_downloader.py
+++ b/unified_downloader/core/async_downloader.py
@@ -1,9 +1,11 @@
 """异步下载器"""
 
 import asyncio
+import logging
+import time
 from typing import Optional, List, Dict, Any, Callable
 
-from unified_downloader.models.enums import Market
+from unified_downloader.models.enums import Market, EventType
 from unified_downloader.models.entities import (
     DownloadResult,
     BatchResult,
@@ -14,6 +16,8 @@ from unified_downloader.models.callbacks import ProgressCallbackType
 from unified_downloader.core.downloader import UnifiedDownloader
 from unified_downloader.core.config import Config, get_default_config
 from unified_downloader.infra import AsyncHTTPClient
+
+logger = logging.getLogger(__name__)
 
 
 class AsyncUnifiedDownloader:
@@ -32,8 +36,12 @@ class AsyncUnifiedDownloader:
     """
 
     def __init__(self, config: Optional[Config] = None):
-        self.config = config or Config()
-        self._downloader = UnifiedDownloader(config)
+        # W40-#50 P1: 之前 self.config 用裸 Config() (不读 config.yaml),
+        # 而 UnifiedDownloader(config=None) 内部又用 get_default_config() —
+        # 两个不同配置实例, cache_enabled 等检查项与实际行为不一致。
+        # 统一为同一个 config (无参时读默认配置)。
+        self.config = config or get_default_config()
+        self._downloader = UnifiedDownloader(self.config)
         self._async_http_client = AsyncHTTPClient()
 
     async def download(
@@ -50,7 +58,8 @@ class AsyncUnifiedDownloader:
         # 如果不使用缓存，直接调用适配器的异步方法
         if not use_cache or not self.config.download.cache_enabled:
             return await self._download_direct(
-                code, year, document_type, market, on_progress, **kwargs
+                code, year, document_type, market, on_progress,
+                use_cache=use_cache, **kwargs
             )
 
         # 检查缓存
@@ -73,7 +82,8 @@ class AsyncUnifiedDownloader:
 
         # 执行下载
         return await self._download_direct(
-            code, year, document_type, market, on_progress, **kwargs
+            code, year, document_type, market, on_progress,
+            use_cache=use_cache, **kwargs
         )
 
     async def _download_direct(
@@ -83,9 +93,12 @@ class AsyncUnifiedDownloader:
         document_type: str,
         market: Optional[Market],
         on_progress: Optional[ProgressCallbackType],
+        use_cache: bool = True,
         **kwargs,
     ) -> DownloadResult:
         """直接下载（不检查缓存）"""
+        start_time = time.time()
+
         if market is None:
             market = self._downloader._detect_market(code)
 
@@ -97,7 +110,32 @@ class AsyncUnifiedDownloader:
                 error_message="无法识别市场",
             )
 
-        return await adapter.async_download(
+        # W40-#50 P1: 之前异步路径完全不碰熔断器 (批量跑时熔断永不打开,
+        # 故障源被无限打) 也不写审计日志。与同步路径对齐。
+        breaker = self._downloader._circuit_breaker_manager.get_breaker(
+            market.value
+        )
+        if not breaker.can_execute():
+            duration_ms = int((time.time() - start_time) * 1000)
+            self._downloader._log_event(
+                EventType.CIRCUIT_OPEN,
+                market, code, year, document_type,
+                False,
+                error_code="CIRCUIT_BREAKER_OPEN",
+                duration_ms=duration_ms,
+            )
+            return DownloadResult(
+                success=False,
+                error_code="CIRCUIT_BREAKER_OPEN",
+                error_message=f"市场 {market.value} 的熔断器已开启，请稍后再试",
+                duration_ms=duration_ms,
+            )
+
+        self._downloader._log_event(
+            EventType.DOWNLOAD_START, market, code, year, document_type, True
+        )
+
+        result = await adapter.async_download(
             http_client=self._async_http_client,
             code=code,
             year=year,
@@ -105,6 +143,51 @@ class AsyncUnifiedDownloader:
             on_progress=on_progress,
             **kwargs,
         )
+
+        duration_ms = int((time.time() - start_time) * 1000)
+        result.duration_ms = duration_ms
+
+        if result.success:
+            breaker.record_success()
+            self._downloader._log_event(
+                EventType.DOWNLOAD_COMPLETE,
+                market, code, year, document_type,
+                True,
+                duration_ms=duration_ms,
+                file_size=result.file_size,
+                source=result.source,
+            )
+            # W40-#50 P1: 之前异步下载的成果永远进不了缓存 (无任何 put
+            # 调用, 缓存只能命中同步路径写入的条目)
+            if (
+                use_cache
+                and self.config.download.cache_enabled
+                and result.file_path
+            ):
+                try:
+                    self._downloader._cache_manager.put(
+                        market.value,
+                        code,
+                        year,
+                        document_type,
+                        file_path=result.file_path,
+                    )
+                except Exception as cache_err:
+                    logger.warning(
+                        f"Cache write failed (download itself succeeded): {cache_err}"
+                    )
+        else:
+            breaker.record_failure()
+            self._downloader._log_event(
+                EventType.DOWNLOAD_FAILED,
+                market, code, year, document_type,
+                False,
+                error_code=result.error_code,
+                error_message=result.error_message,
+                duration_ms=duration_ms,
+            )
+
+        return result
 
     async def batch_download(
         self,

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -37,6 +37,7 @@ from unified_downloader.core.config import Config, get_default_config
 from unified_downloader.exceptions import (
     MarketUnrecognizedError,
     CircuitBreakerOpenError,
+    CheckpointError,
 )
 
 
@@ -107,7 +108,11 @@ class UnifiedDownloader:
             checkpoint_dir=self.config.checkpoint_dir,
         )
 
-        self._circuit_breaker_manager = CircuitBreakerManager()
+        # W40-#50 P1: 传入 config.circuit_breaker — 之前 YAML 里的熔断配置
+        # 因 manager/get_breaker 都不传参被静默丢弃
+        self._circuit_breaker_manager = CircuitBreakerManager(
+            default_config=self.config.circuit_breaker
+        )
 
         self._audit_logger = (
             AuditLogger(
@@ -201,11 +206,22 @@ class UnifiedDownloader:
         # 检查断点
         checkpoint = None
         if self.config.download.checkpoint_enabled:
-            checkpoint = self._checkpoint_manager.resume(task_id, f"{market}:{code}")
+            # W40-#50 P1: 断点读失败 (损坏等) 不再毒化该 task_id 的全部
+            # 后续下载 — 当作无断点从头下载
+            try:
+                checkpoint = self._checkpoint_manager.resume(
+                    task_id, f"{market}:{code}"
+                )
+            except CheckpointError as e:
+                logger.warning(f"Checkpoint resume failed, downloading fresh: {e}")
+                checkpoint = None
 
         # 检查熔断器
+        # W40-#50 P1: 用 can_execute() 而非 is_open — half_open 状态下
+        # is_open 为 False, 之前 5 个线程会同时涌向刚恢复的源,
+        # "半开最多放 N 个试探请求" 的设计完全没生效
         breaker = self._circuit_breaker_manager.get_breaker(market.value)
-        if breaker.is_open:
+        if not breaker.can_execute():
             duration_ms = int((time.time() - start_time) * 1000)
             self._log_event(
                 EventType.CIRCUIT_OPEN,
@@ -230,16 +246,24 @@ class UnifiedDownloader:
             raise MarketUnrecognizedError(code)
 
         # 临时覆盖 PDF 转换设置
+        # W40-#50 P1: 之前直接改共享 adapter 的私有标志且从不恢复 —
+        # 调一次 convert_to_pdf=True 后, 之后所有 convert_to_pdf=None 的
+        # 调用也静默转 PDF; batch_download 线程池并发任务互相污染。
+        # 现在 try/finally 恢复原值。
+        _saved_flags = {}
         if convert_to_pdf is not None and market == Market.M:
+            _saved_flags["_convert_to_pdf"] = adapter._convert_to_pdf  # type: ignore[attr-defined]
             adapter._convert_to_pdf = convert_to_pdf  # type: ignore[attr-defined]
 
         # --no-cache 同时跳过翻译缓存
         if not use_cache and market == Market.M:
+            _saved_flags["_use_translate_cache"] = adapter._use_translate_cache  # type: ignore[attr-defined]
             adapter._use_translate_cache = False  # type: ignore[attr-defined]
 
         # 临时覆盖翻译设置
         if translate is not None:
             if market == Market.M:
+                _saved_flags["_translate_enabled"] = adapter._translate_enabled  # type: ignore[attr-defined]
                 adapter._translate_enabled = translate  # type: ignore[attr-defined]
             elif translate:
                 logger.warning(
@@ -285,13 +309,22 @@ class UnifiedDownloader:
                     and self.config.download.cache_enabled
                     and result.file_path
                 ):
-                    self._cache_manager.put(
-                        market.value,
-                        code,
-                        year,
-                        document_type,
-                        file_path=result.file_path,
-                    )
+                    # W40-#50 P1: 缓存写失败不应把成功下载记为市场失败 —
+                    # 之前 sqlite locked / 磁盘满会穿透到 except Exception,
+                    # 用户拿到 UNEXPECTED_ERROR (文件其实已完整落盘), 且
+                    # 连续 5 次缓存故障误开该市场熔断器
+                    try:
+                        self._cache_manager.put(
+                            market.value,
+                            code,
+                            year,
+                            document_type,
+                            file_path=result.file_path,
+                        )
+                    except Exception as cache_err:
+                        logger.warning(
+                            f"Cache write failed (download itself succeeded): {cache_err}"
+                        )
 
                 # 清理断点
                 if self.config.download.checkpoint_enabled:
@@ -351,6 +384,13 @@ class UnifiedDownloader:
                 error_message=str(e),
                 duration_ms=duration_ms,
             )
+        finally:
+            # W40-#50 P1: 恢复临时覆盖的 adapter 标志 (之前永久污染)
+            for _attr, _old in _saved_flags.items():
+                try:
+                    setattr(adapter, _attr, _old)
+                except Exception:
+                    pass
 
 
     def _restore_semantic_cache_path(

--- a/unified_downloader/infra/cache.py
+++ b/unified_downloader/infra/cache.py
@@ -3,6 +3,7 @@
 import sqlite3
 import hashlib
 import shutil
+from contextlib import closing
 from pathlib import Path
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
@@ -46,7 +47,7 @@ class CacheManager:
 
     def _init_db(self) -> None:
         """初始化数据库"""
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS cache_entries (
                     key TEXT PRIMARY KEY,
@@ -91,7 +92,7 @@ class CacheManager:
         """
         key = self._make_key(market, code, year, doc_type)
 
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             row = conn.execute(
                 """
                 SELECT file_path, expires_at FROM cache_entries
@@ -172,7 +173,7 @@ class CacheManager:
         if str(file_path) != str(cached_path):
             shutil.copy2(str(file_path), str(cached_path))
 
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO cache_entries
@@ -202,7 +203,7 @@ class CacheManager:
         except Exception:
             pass
 
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             conn.execute("DELETE FROM cache_entries WHERE key = ?", (key,))
 
     def _maybe_cleanup(self) -> None:
@@ -211,10 +212,28 @@ class CacheManager:
 
         if total_size > self._max_size_bytes:
             self.clear(older_than_days=7)
+            # W40-#50 P1: 之前唯一手段是删 7 天前的条目 — 集中批量拉取时
+            # (一天内写超 max_size) 所有条目 created_at 都是今天, 一个都
+            # 删不掉, 缓存无限增长。回退按 last_access 最久未用淘汰 (LRU)
+            # 直到回到限额内。
+            while self.get_size() > self._max_size_bytes:
+                with closing(
+                    sqlite3.connect(str(self._db_path))
+                ) as conn, conn:
+                    victim = conn.execute(
+                        """
+                        SELECT key, file_path FROM cache_entries
+                        ORDER BY (last_access IS NULL) DESC, last_access ASC
+                        LIMIT 1
+                    """
+                    ).fetchone()
+                if not victim:
+                    break
+                self._delete_entry(victim[0], victim[1])
 
     def get_size(self) -> int:
         """获取缓存总大小（从SQLite聚合，O(1)）"""
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             try:
                 result = conn.execute(
                     "SELECT COALESCE(SUM(size), 0) FROM cache_entries"
@@ -247,7 +266,7 @@ class CacheManager:
         """
         count = 0
 
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             if older_than_days is None:
                 # 清理所有缓存
                 rows = conn.execute(
@@ -282,7 +301,7 @@ class CacheManager:
 
     def get_stats(self) -> Dict[str, Any]:
         """获取缓存统计信息"""
-        with sqlite3.connect(str(self._db_path)) as conn:
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             total_entries = conn.execute(
                 "SELECT COUNT(*) FROM cache_entries"
             ).fetchone()[0]

--- a/unified_downloader/infra/checkpoint.py
+++ b/unified_downloader/infra/checkpoint.py
@@ -1,12 +1,16 @@
 """断点续传管理"""
 
 import json
+import logging
+import os
 import sys
 from pathlib import Path
 from typing import Optional, Dict, Any
 from datetime import datetime
 
 from unified_downloader.exceptions import CheckpointError
+
+logger = logging.getLogger(__name__)
 
 # Platform-compatible file locking
 if sys.platform == "win32":
@@ -86,10 +90,16 @@ class CheckpointManager:
         }
 
         try:
-            with open(checkpoint_path, "w", encoding="utf-8") as f:
+            # W40-#50 P1: tmp+rename 原子写 — 之前 open("w") 在拿 flock 前
+            # 就截断目标文件且 json.dump 直写, 写一半崩溃留下半截 JSON,
+            # 之后 get() 每次都抛 CheckpointError 毒化该 task_id 的全部
+            # 后续下载, 直到人工删文件
+            tmp_path = checkpoint_path.with_suffix(".json.tmp")
+            with open(tmp_path, "w", encoding="utf-8") as f:
                 self._lock_file(f)
                 json.dump(checkpoint_data, f, ensure_ascii=False, indent=2)
                 self._unlock_file(f)
+            os.replace(tmp_path, checkpoint_path)
         except Exception as e:
             raise CheckpointError(f"保存断点失败: {e}")
 
@@ -114,6 +124,17 @@ class CheckpointManager:
                 data = json.load(f)
                 self._unlock_file(f)
                 return data
+        except json.JSONDecodeError as e:
+            # W40-#50 P1: 损坏 (截断) 的断点文件不再抛 CheckpointError 毒化
+            # 后续下载 — 移除坏文件并当作无断点, 从头下载
+            logger.warning(
+                f"Corrupted checkpoint {checkpoint_path} removed, restarting fresh: {e}"
+            )
+            try:
+                checkpoint_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return None
         except Exception as e:
             raise CheckpointError(f"读取断点失败: {e}")
 

--- a/unified_downloader/infra/circuit_breaker.py
+++ b/unified_downloader/infra/circuit_breaker.py
@@ -1,5 +1,6 @@
 """熔断器实现"""
 
+import threading
 from enum import Enum
 from typing import Optional, Callable, Any, Dict
 from dataclasses import dataclass
@@ -40,6 +41,12 @@ class CircuitBreaker:
     ):
         self.name = name
         self.config = config or CircuitBreakerConfig()
+        # W40-#50 P1: 之前全文件无锁 — batch_download 的线程池并发调
+        # record_failure (_failure_count += 1 非原子) / record_success
+        # (= 0 直接清零) 互相覆盖, 失败计数可能永远到不了阈值;
+        # state property 在读操作里做状态迁移同样有竞态。RLock 允许
+        # property 与 mutating method 嵌套。
+        self._lock = threading.RLock()
         self._state = CircuitState.CLOSED
         self._failure_count = 0
         self._success_count = 0
@@ -50,13 +57,14 @@ class CircuitBreaker:
     @property
     def state(self) -> CircuitState:
         """获取当前状态"""
-        if self._state == CircuitState.OPEN:
-            # 检查是否应该转换到半开状态
-            if self._last_failure_time:
-                elapsed = (datetime.now() - self._last_failure_time).total_seconds()
-                if elapsed >= self.config.timeout:
-                    self._transition_to(CircuitState.HALF_OPEN)
-        return self._state
+        with self._lock:
+            if self._state == CircuitState.OPEN:
+                # 检查是否应该转换到半开状态
+                if self._last_failure_time:
+                    elapsed = (datetime.now() - self._last_failure_time).total_seconds()
+                    if elapsed >= self.config.timeout:
+                        self._transition_to(CircuitState.HALF_OPEN)
+            return self._state
 
     @property
     def is_closed(self) -> bool:
@@ -75,6 +83,10 @@ class CircuitBreaker:
 
     def record_success(self) -> None:
         """记录成功调用"""
+        with self._lock:
+            self._record_success_unlocked()
+
+    def _record_success_unlocked(self) -> None:
         if self._state == CircuitState.HALF_OPEN:
             self._success_count += 1
             if self._success_count >= self.config.success_threshold:
@@ -84,6 +96,10 @@ class CircuitBreaker:
 
     def record_failure(self) -> None:
         """记录失败调用"""
+        with self._lock:
+            self._record_failure_unlocked()
+
+    def _record_failure_unlocked(self) -> None:
         self._failure_count += 1
         self._last_failure_time = datetime.now()
 
@@ -112,6 +128,10 @@ class CircuitBreaker:
 
     def can_execute(self) -> bool:
         """检查是否可以执行"""
+        with self._lock:
+            return self._can_execute_unlocked()
+
+    def _can_execute_unlocked(self) -> bool:
         if self.state == CircuitState.CLOSED:
             return True
 
@@ -142,14 +162,20 @@ class CircuitBreaker:
 
         try:
             result = func(*args, **kwargs)
-            self.record_success()
+            with self._lock:
+                self._record_success_unlocked()
             return result
         except Exception:
-            self.record_failure()
+            with self._lock:
+                self._record_failure_unlocked()
             raise
 
     def get_status(self) -> Dict[str, Any]:
         """获取熔断器状态"""
+        with self._lock:
+            return self._get_status_unlocked()
+
+    def _get_status_unlocked(self) -> Dict[str, Any]:
         return {
             "name": self.name,
             "state": self.state.value,
@@ -163,7 +189,8 @@ class CircuitBreaker:
 
     def reset(self) -> None:
         """重置熔断器"""
-        self._transition_to(CircuitState.CLOSED)
+        with self._lock:
+            self._transition_to(CircuitState.CLOSED)
 
 
 class CircuitBreakerManager:
@@ -173,15 +200,21 @@ class CircuitBreakerManager:
     管理多个市场的熔断器
     """
 
-    def __init__(self):
+    def __init__(self, default_config: Optional[CircuitBreakerConfig] = None):
         self._breakers: Dict[str, CircuitBreaker] = {}
+        # W40-#50 P1: 之前 Config.from_dict 精心解析的 circuit_breaker
+        # 配置因 manager/get_breaker 都不传参被静默丢弃 (YAML 设
+        # failure_threshold: 10 实际仍是默认 5)
+        self._default_config = default_config
 
     def get_breaker(
         self, market: str, config: Optional[CircuitBreakerConfig] = None
     ) -> CircuitBreaker:
         """获取或创建熔断器"""
         if market not in self._breakers:
-            self._breakers[market] = CircuitBreaker(market, config)
+            self._breakers[market] = CircuitBreaker(
+                market, config or self._default_config
+            )
         return self._breakers[market]
 
     def get_all_status(self) -> Dict[str, Dict[str, Any]]:

--- a/unified_downloader/infra/http_client.py
+++ b/unified_downloader/infra/http_client.py
@@ -1,5 +1,6 @@
 """HTTP客户端封装"""
 
+import asyncio
 import hashlib
 import logging
 import time
@@ -17,6 +18,29 @@ from unified_downloader.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_retry_after(value: Optional[str], default: int = 60) -> int:
+    """解析 Retry-After 头。W40-#50 P1: 之前裸 int() 遇 HTTP-date 格式
+    (如 'Wed, 21 Oct 2015 07:28:00 GMT') 抛 ValueError 落入通用异常分支,
+    退避节奏完全丢失; 非法/缺失值统一回退 default 秒。"""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _md5_of_file(path: Path) -> str:
+    """流式计算整个文件的 MD5。W40-#50 P1: 断点续传 ('ab' 模式) 时增量
+    哈希只覆盖新到字节, 与全文件 expected_md5 永不相等 → 校验必失败并
+    把整个完整文件删掉; 下载完成后对磁盘全文件统一校验。"""
+    md5 = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            md5.update(chunk)
+    return md5.hexdigest()
 
 
 class HTTPClient:
@@ -94,16 +118,19 @@ class HTTPClient:
                 response = self.session.request(method, url, **kwargs)
 
                 if response.status_code == 429:
-                    # Rate limit - wait and retry
-                    retry_after = int(response.headers.get("Retry-After", 60))
+                    # W40-#50 P1: 末次尝试不再先白睡再抛错; Retry-After
+                    # 兼容 HTTP-date / 非法值 (回退 60s)
+                    if attempt >= self.max_retries - 1:
+                        raise RateLimitError(f"请求过于频繁 (429): {url}")
+                    retry_after = _parse_retry_after(
+                        response.headers.get("Retry-After")
+                    )
                     wait_time = min(retry_after, self.max_backoff)
                     logger.warning(
                         f"Rate limited (429), waiting {wait_time}s before retry..."
                     )
                     time.sleep(wait_time)
-                    if attempt < self.max_retries - 1:
-                        continue
-                    raise RateLimitError(f"请求过于频繁 (429): {url}")
+                    continue
 
                 if response.status_code == 404:
                     raise FileIntegrityError(f"资源不存在 (404): {url}")
@@ -223,7 +250,10 @@ class HTTPClient:
                             }
                         )
 
-        md5_result = md5_hash.hexdigest()
+        # W40-#50 P1: 续传时增量 md5 只覆盖新到字节, 统一改为对磁盘上的
+        # 完整文件做一次流式校验 (否则 expected_md5 校验 100% 失败并删掉
+        # 整个完整文件)
+        md5_result = _md5_of_file(file_path)
 
         # 校验MD5
         if expected_md5 and md5_result != expected_md5:
@@ -323,7 +353,15 @@ class AsyncHTTPClient:
             try:
                 async with session.request(method, url, **kwargs) as response:
                     if response.status == 429:
-                        raise RateLimitError(f"请求过于频繁 (429): {url}")
+                        # W40-#50 P1: 与同步版对齐 — 等待后重试, 而不是
+                        # 第一次 429 就抛错 (异步客户端之前完全不重试限流)
+                        if attempt >= self.max_retries - 1:
+                            raise RateLimitError(f"请求过于频繁 (429): {url}")
+                        retry_after = _parse_retry_after(
+                            response.headers.get("Retry-After")
+                        )
+                        await self._sleep(min(retry_after, self.max_backoff))
+                        continue
 
                     if response.status == 404:
                         raise FileIntegrityError(f"资源不存在 (404): {url}")
@@ -339,7 +377,11 @@ class AsyncHTTPClient:
                         "content_type": response.content_type,
                     }
 
-            except aiohttp.ClientTimeout:
+            except (asyncio.TimeoutError, aiohttp.ServerTimeoutError):
+                # W40-#50 P1: 之前写的是 except aiohttp.ClientTimeout —
+                # ClientTimeout 是超时*配置*类不是异常类, 任何异常传播到
+                # 这里都会 TypeError ("catching classes that do not inherit
+                # from BaseException") 掩盖原始异常
                 last_exception = DownloadTimeoutError(f"请求超时: {url}")
                 if attempt < self.max_retries - 1:
                     await self._sleep(
@@ -380,8 +422,6 @@ class AsyncHTTPClient:
 
     async def _sleep(self, seconds: float):
         """异步睡眠"""
-        import asyncio
-
         await asyncio.sleep(seconds)
 
     async def download_file(
@@ -456,7 +496,9 @@ class AsyncHTTPClient:
                                 }
                             )
 
-            md5_result = md5_hash.hexdigest()
+            # W40-#50 P1: 同步版同样的问题 — 续传增量哈希 ≠ 全文件哈希,
+            # 下载完成后对磁盘完整文件统一校验
+            md5_result = _md5_of_file(file_path)
 
             if expected_md5 and md5_result != expected_md5:
                 file_path.unlink(missing_ok=True)


### PR DESCRIPTION
## 背景

#50 P1-并发批次：core/infra 层七个缺陷 + 一个测试暴露出的潜伏 bug。

## 修复内容

### 1. 熔断器三重失效 → 修复（`circuit_breaker.py` + `downloader.py`）
- **加 RLock**：之前全文件无锁——线程池并发下 `record_failure` 的 `+= 1` 被 `record_success` 的 `= 0` 直接覆盖，失败计数可能永远到不了阈值；`state` property 在读操作里做状态迁移同样有竞态
- **config 接线**：`CircuitBreakerManager(default_config=...)`——之前 `config.yaml` 里精心解析的 `circuit_breaker` 配置因 manager/get_breaker 都不传参被静默丢弃（YAML 设 `failure_threshold: 10` 实际仍是默认 5）
- **half_open 预算生效**：门控从 `is_open` 改为 `can_execute()`——之前半开状态下 5 个线程同时涌向刚恢复的源，"半开最多 3 个试探"的设计从未生效

### 2. 断点续传 MD5 必败删文件 → 修复（`http_client.py` sync+async）
续传用 `"ab"` 模式，增量哈希只覆盖新到字节，与全文件 `expected_md5` 永不相等 → 100% 校验失败并**删除整个完整文件**。改为下载完成后对磁盘全文件流式校验（`_md5_of_file`）。

### 3. adapter 标志污染 → try/finally 恢复（`downloader.py`）
之前 `download()` 直接改共享 adapter 的 `_convert_to_pdf` 等私有标志且从不恢复——调一次 `--pdf` 后**之后所有调用静默转 PDF**；`batch_download` 5 线程并发写同一标志互相污染。

### 4. 异步链路裸奔 → 接线（`async_downloader.py` + `m_stock.py`）
- config 统一实例（之前 `裸 Config()` 与内部 `get_default_config()` 双实例，检查项与实际行为不一致）
- 接入熔断 `can_execute` 门控 + `record_success/failure` + 审计事件（之前异步批量跑熔断永不打开）
- 成功结果写入缓存（之前异步成果永远不进缓存）
- m_stock 异步路径的 weasyprint 转换 / 翻译 `subprocess(timeout=1800)` 移入 `asyncio.to_thread`（之前最长冻结事件循环 30 分钟，其余并发任务全部停摆）

### 5. checkpoint 死功能+毒化 → 修复（`checkpoint.py`）
tmp+rename 原子写（之前 `open("w")` 拿锁前截断 + 直写，崩溃留半截 JSON）；损坏文件清理后返回 `None`（之前抛 `CheckpointError` 毒化该 task_id 全部后续下载）；`downloader.resume` 失败按无断点处理。

### 6. 缓存 → 修复（`cache.py` + `downloader.py`）
- 写失败隔离：sqlite locked / 磁盘满不再穿透成市场失败（之前文件已落盘却报 `UNEXPECTED_ERROR`，连续 5 次误开熔断）
- 超限清理加 `last_access` LRU 回退：之前唯一手段是删 7 天前条目，单日批量写超 `max_size` 时全部失效、缓存无限增长
- sqlite 连接显式关闭（`closing()`，不再依赖 GC 回收 fd）

### 7. 429 重试 → 修复（`http_client.py`）
`Retry-After` 兼容 HTTP-date 格式（之前裸 `int()` 抛 ValueError 打乱退避）；末次尝试不再先白睡再抛错；异步版从"第一次 429 直接抛错"对齐为"等待后重试"。

### 8. 附带潜伏 bug：`except aiohttp.ClientTimeout` 是配置类非异常类
任何异常传播到该 except 都会 `TypeError: catching classes...` 掩盖原始异常——本批 429 测试暴露，改为 `asyncio.TimeoutError + aiohttp.ServerTimeoutError`。

## 测试

新增 `test_p1_concurrency_infra.py` **24 用例**（续传 MD5 真续传场景、熔断并发 10 线程×100 次、half-open 预算时间旅行、标志恢复、缓存写失败隔离、LRU 淘汰、checkpoint 损坏容错、异步 429 重试/耗尽）；全量 **208 passed**。

Refs #50（P1-并发七项勾选）