### PR TITLE
fix(P2): 入口与打磨 — MCP 枚举/阻塞/路径、CLI 死参数生效、.html 判定、adr_map 容错

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,9 @@ packages = [{include = "unified_downloader"}]
 [tool.poetry.scripts]
 unified-downloader = "unified_downloader.cli:cli"
 
+# W40-#50: MCP server 等代码使用 3.10+ 语法/特性, ^3.9 声明与实际不符
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 requests = ">=2.28"
 aiohttp = ">=3.8"
 pydantic = ">=2.0,<3.0"

--- a/src/unified_downloader_mcp_server.py
+++ b/src/unified_downloader_mcp_server.py
@@ -65,7 +65,7 @@ async def list_tools() -> list[Tool]:
                     "year": {"type": "integer", "description": "年份，如 2024"},
                     "market": {
                         "type": "string",
-                        "enum": ["a", "h", "m"],
+                        "enum": ["a", "h", "m", "e"],
                         "description": "市场: a=A股, h=港股, m=美股",
                     },
                     "document_type": {
@@ -88,7 +88,7 @@ async def list_tools() -> list[Tool]:
                     "year": {"type": "integer", "description": "年份"},
                     "market": {
                         "type": "string",
-                        "enum": ["a", "h", "m"],
+                        "enum": ["a", "h", "m", "e"],
                         "description": "市场",
                     },
                     "document_type": {
@@ -114,7 +114,7 @@ async def list_tools() -> list[Tool]:
                     "code": {"type": "string", "description": "股票代码"},
                     "market": {
                         "type": "string",
-                        "enum": ["a", "h", "m"],
+                        "enum": ["a", "h", "m", "e"],
                         "description": "市场",
                     },
                     "document_type": {
@@ -142,7 +142,7 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "market": {
                         "type": "string",
-                        "enum": ["a", "h", "m"],
+                        "enum": ["a", "h", "m", "e"],
                         "default": "a",
                         "description": "市场",
                     },
@@ -169,7 +169,11 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             market = arguments.get("market", "a")
             doc_type = arguments.get("document_type", "annual_report")
 
-            result = downloader.download(
+            # W40-#50: 同步下载 (真实网络+磁盘, 分钟级) 移出事件循环,
+            # 之前直接在 async handler 里调用会冻结 stdio server, 客户端
+            # 极易判超时
+            result = await asyncio.to_thread(
+                downloader.download,
                 code=code,
                 year=year,
                 document_type=doc_type,
@@ -238,7 +242,9 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             else:
                 adapter = MStockAdapter(downloader._http_client, [])
 
-            results = adapter.search(code, year, doc_type)
+            results = await asyncio.to_thread(
+                adapter.search, code, year, doc_type
+            )
 
             return CallToolResult(
                 content=[
@@ -283,7 +289,9 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             else:
                 adapter = MStockAdapter(downloader._http_client, [])
 
-            years = adapter.get_available_years(code, doc_type)
+            years = await asyncio.to_thread(
+                adapter.get_available_years, code, doc_type
+            )
 
             return CallToolResult(
                 content=[
@@ -304,14 +312,14 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             )
 
         elif name == "get_download_status":
-            cache_dir = Path("data/cache")
+            cache_dir = PROJECT_ROOT / "data" / "cache"
             cache_size = (
                 sum(f.stat().st_size for f in cache_dir.rglob("*") if f.is_file())
                 if cache_dir.exists()
                 else 0
             )
 
-            downloads_dir = Path("downloads")
+            downloads_dir = PROJECT_ROOT / "downloads"
             download_count = (
                 len(list(downloads_dir.rglob("*"))) if downloads_dir.exists() else 0
             )
@@ -353,7 +361,8 @@ async def call_tool(name: str, arguments: Any) -> CallToolResult:
             }
             config = demo_configs.get(market, demo_configs["a"])
 
-            result = downloader.download(
+            result = await asyncio.to_thread(
+                downloader.download,
                 code=config["code"],
                 year=config["year"],
                 document_type=config["type"],

--- a/tests/test_p2_polish.py
+++ b/tests/test_p2_polish.py
@@ -1,0 +1,212 @@
+"""
+Regression tests for P2 打磨批次 (W40-#50).
+
+覆盖: MCP market 枚举补 e + 守卫测试扫 MCP schema、_primary_doc_ext
+(.htm/.html 与 %20exhibit)、adr_map 损坏容错、a_stock https、限速单
+key、eu_stock async 异常一致性、batch --errors 真实生效。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from unified_downloader.utils.adr_map import load_adr_map  # noqa: E402
+from unified_downloader.adapters.m_stock import _primary_doc_ext  # noqa: E402
+
+
+# ═══ MCP market 枚举 ═══
+
+
+class TestMcpMarketEnum:
+    """W40-#50: MCP 的 4 处 market 枚举之前都漏了 EU 的 "e" —
+    专门防"加市场漏改入口"的一致性测试只扫 cli.py, 恰好没覆盖到
+    唯一真漏改的入口。"""
+
+    MCP_FILE = ROOT / "src" / "unified_downloader_mcp_server.py"
+    CLI_FILE = ROOT / "unified_downloader" / "cli.py"
+
+    CANONICAL = {"a", "h", "m", "e"}  # 与 models.enums.Market 对齐
+
+    def _mcp_market_enums(self):
+        text = self.MCP_FILE.read_text()
+        # 所有 market 属性下的 enum 列表
+        enums = []
+        for m in re.finditer(r'"market":\s*\{[^{}]*?"enum":\s*\[([^\]]+)\]', text, re.S):
+            enums.append(set(re.findall(r'"(\w)"', m.group(1))))
+        return enums
+
+    def _cli_single_letter_choices(self):
+        text = self.CLI_FILE.read_text()
+        choices = []
+        for m in re.finditer(r'click\.Choice\(\s*\[([^\]]+)\]', text):
+            flags = re.findall(r'"(\w)"', m.group(1))
+            if flags:
+                choices.append(set(flags))
+        return choices
+
+    def test_mcp_has_market_enums_to_check(self):
+        assert len(self._mcp_market_enums()) >= 4
+
+    def test_mcp_market_enums_match_canonical(self):
+        for i, enum in enumerate(self._mcp_market_enums()):
+            assert enum == self.CANONICAL, (
+                f"MCP 第 {i + 1} 处 market 枚举 {sorted(enum)} != "
+                f"{sorted(self.CANONICAL)} — 加市场时漏改了 MCP 入口"
+            )
+
+    def test_cli_market_choices_match_canonical(self):
+        """守卫扩展到 cli.py: 任何单字母 Choice 列表都必须是完整市场集
+        (防'加市场漏改某个命令')"""
+        singles = [c for c in self._cli_single_letter_choices() if len(c) <= 4]
+        assert singles, "cli.py 应至少有一个 market Choice"
+        for i, c in enumerate(singles):
+            assert c == self.CANONICAL, (
+                f"cli.py 第 {i + 1} 处单字母 Choice {sorted(c)} 缺市场: "
+                f"{sorted(self.CANONICAL - c)}"
+            )
+
+    def test_mcp_uses_to_thread_for_blocking_download(self):
+        text = self.MCP_FILE.read_text()
+        assert "asyncio.to_thread(\n                downloader.download" in text, (
+            "MCP async handler 里的同步下载必须走 to_thread (之前冻结 stdio 循环)"
+        )
+
+    def test_mcp_status_paths_anchored_to_project_root(self):
+        text = self.MCP_FILE.read_text()
+        assert 'Path("data/cache")' not in text
+        assert 'Path("downloads")' not in text
+
+
+# ═══ _primary_doc_ext ═══
+
+
+class TestPrimaryDocExt:
+    def test_htm(self):
+        assert _primary_doc_ext("https://sec.gov/Archives/x.htm") == ".html"
+
+    def test_html_not_saved_as_txt(self):
+        # W40-#50 回归核心: ".htm" 差一个 l 漏判 ".html" → 存 .txt
+        assert _primary_doc_ext("https://sec.gov/Archives/x.html") == ".html"
+
+    def test_exhibit_encoded_space(self):
+        # " exhibit" 是死条件 (URL 空格编码为 %20)
+        assert _primary_doc_ext("https://sec.gov/Archives/x%20exhibit") == ".html"
+
+    def test_other_extents_stay_txt(self):
+        assert _primary_doc_ext("https://sec.gov/Archives/x.txt") == ".txt"
+        assert _primary_doc_ext("https://sec.gov/Archives/noext") == ".txt"
+
+
+# ═══ adr_map 容错 ═══
+
+
+class TestAdrMapCorruption:
+    def test_corrupt_json_returns_empty_map(self, tmp_path):
+        bad = tmp_path / "adr_map.json"
+        bad.write_text('{"use_hk_source": {"MNSO.US": ', encoding="utf-8")
+
+        assert load_adr_map(bad) == {}  # 之前 json.loads 直接抛
+
+    def test_valid_json_still_loads(self, tmp_path):
+        good = tmp_path / "adr_map.json"
+        good.write_text(json.dumps({"use_sec_20f_only": {"NVO.US": "20-F only"}}),
+                        encoding="utf-8")
+
+        assert load_adr_map(good)["use_sec_20f_only"]["NVO.US"] == "20-F only"
+
+    def test_a_stock_uses_https(self):
+        from unified_downloader.adapters.a_stock import CninfoAPI
+
+        assert CninfoAPI.PDF_BASE_URL.startswith("https://")
+
+
+# ═══ 限速: 常态路径只等实际要用的 key ═══
+
+
+class TestRateLimiterSingleKey:
+    def test_edgar_success_waits_only_edgar_key(self):
+        from unittest.mock import MagicMock, patch
+
+        sys.path.insert(0, str(ROOT / "unified_downloader"))
+        from adapters.m_stock import MStockAdapter
+
+        adapter = MStockAdapter(MagicMock(), [])
+        waits = []
+
+        with patch.object(adapter, "_rate_limiter") as rl, \
+             patch.object(adapter, "_init_edgar", return_value=True), \
+             patch.object(adapter, "_search_edgar", return_value=[]) as mock_search:
+            rl.wait.side_effect = lambda key: waits.append(key)
+
+            result = adapter._search_filings("AAPL", "10-K", 2026)
+
+            assert result == []
+            mock_search.assert_called_once()
+            # W40-#50: 之前常态路径连等 edgar_search + sec_api_search 两个
+            # key, 为从未发生的 sec-api 调用白睡 ~5s
+            assert waits == ["edgar_search"]
+
+
+# ═══ eu_stock async 异常一致性 ═══
+
+
+class TestAsyncAdapterErrorConsistency:
+    def test_not_implemented_becomes_failure_result(self, tmp_path, monkeypatch):
+        """eu_stock 骨架抛 NotImplementedError — 之前单发 download() 直接
+        炸给调用方 (sync 路径却兜成失败结果)"""
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+        from unified_downloader.models.enums import Market
+
+        ad = AsyncUnifiedDownloader()
+        r = asyncio.run(ad.download("LVMH", 2026, "annual_report", market=Market.E))
+
+        assert r.success is False
+        assert r.error_code == "DOWNLOAD_ERROR"
+
+
+# ═══ batch --errors 真实生效 ═══
+
+
+class TestBatchMaxErrors:
+    def test_batch_aborts_when_errors_exceeded(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.downloader import UnifiedDownloader
+        from unified_downloader.models.enums import Market
+
+        d = UnifiedDownloader()
+        gate = threading.Event()
+        started = []
+        executed = []
+
+        def fake_download(self, code, year=None, document_type="annual_report",
+                          market=None, use_cache=True, on_progress=None, **kw):
+            started.append(code)
+            if code == "F1":          # 第一个任务失败并卡住后续调度窗口
+                gate.wait(2)
+                from unified_downloader.models.entities import DownloadResult
+                return DownloadResult(success=False, error_code="X",
+                                      error_message="boom")
+            gate.wait(2)              # 让 F1 的失败先计入
+            executed.append(code)
+            from unified_downloader.models.entities import DownloadResult
+            return DownloadResult(success=True)
+
+        monkeypatch.setattr(UnifiedDownloader, "download", fake_download)
+
+        tasks = [{"code": c, "market": Market.M} for c in ["F1", "OK1", "OK2", "OK3"]]
+        result = d.batch_download(tasks, max_workers=1, max_errors=0)
+        gate.set()
+
+        assert result.failed >= 1
+        assert result.metadata and result.metadata.get("aborted") is True
+        # max_workers=1 串行: F1 失败后 (failed=1 > max_errors=0) 取消剩余
+        assert "OK3" not in executed

--- a/unified_downloader/adapters/a_stock.py
+++ b/unified_downloader/adapters/a_stock.py
@@ -21,7 +21,9 @@ class CninfoAPI:
     """巨潮资讯API封装"""
 
     # PDF下载基础URL
-    PDF_BASE_URL = "http://static.cninfo.com.cn/finalpage"
+    # W40-#50: 与同文件全文检索 URL 统一 https (混用 http 有被劫持/
+    # 重定向风险)
+    PDF_BASE_URL = "https://static.cninfo.com.cn/finalpage"
 
     # 支持的报告类别
     CATEGORIES = {

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -27,6 +27,20 @@ from unified_downloader.exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def _primary_doc_ext(link: str) -> str:
+    """primary doc 链接 → 保存扩展名。
+
+    W40-#50: 之前 ``link.endswith(".htm")`` 漏判 ``.html`` (差一个 l),
+    EDGAR 上少数 primary doc 以 .html 结尾会被存成 .txt, 后续图片内嵌
+    与 PDF 转换全部跳过; ``" exhibit" in link`` 是死条件 (URL 空格被
+    编码为 %20 永不命中), 改判 ``%20exhibit``。
+    """
+    lower = link.lower()
+    if lower.endswith((".htm", ".html")) or "%20exhibit" in lower:
+        return ".html"
+    return ".txt"
+
+
 class MStockAdapter(BaseStockAdapter):
     """
     美股下载适配器
@@ -388,9 +402,10 @@ class MStockAdapter(BaseStockAdapter):
         - 记录 edgar init / search / sec_api 各阶段耗时
         - 解决“downloader 120s 讴 “unknown error” 问题：能定位是哪一步慢
         """
-        # 应用速率限制
+        # W40-#50: 之前常态路径 (edgar 成功) 也要连等两个限速 key,
+        # 为从未发生的 sec-api 调用白睡一个 interval (默认 5s), 批量下
+        # 显著拖慢; sec-api 的等待移到真正要调它的分支
         self._rate_limiter.wait("edgar_search")
-        self._rate_limiter.wait("sec_api_search")
 
         last_error = None
         _t_search = time.monotonic()
@@ -422,6 +437,7 @@ class MStockAdapter(BaseStockAdapter):
 
         # edgartools失败，回退到sec-api (付费)，带重试
         if self._api_key:
+            self._rate_limiter.wait("sec_api_search")
             for attempt in range(self.MAX_RETRIES):
                 try:
                     return self._search_sec_api(ticker, form_type, year, size)
@@ -1242,9 +1258,7 @@ class MStockAdapter(BaseStockAdapter):
                 pass
 
         # 确定文件扩展名
-        ext = ".txt"
-        if link.endswith(".htm") or " exhibit" in link.lower():
-            ext = ".html"
+        ext = _primary_doc_ext(link)
 
         # 构建保存路径
         file_path = self._build_file_path(
@@ -1501,9 +1515,7 @@ class MStockAdapter(BaseStockAdapter):
             except (ValueError, IndexError):
                 pass
 
-        ext = ".txt"
-        if link.endswith(".htm"):
-            ext = ".html"
+        ext = _primary_doc_ext(link)
 
         file_path = self._build_file_path(
             ticker, file_year, form_type.replace("-", ""), ext

--- a/unified_downloader/cli.py
+++ b/unified_downloader/cli.py
@@ -316,7 +316,10 @@ def download_batch(cli_ctx, file, output, workers, errors, verbose):
             click.echo(f"  ... 还有 {len(tasks) - 10} 个任务")
 
     # 执行批量下载
-    result = downloader.batch_download(tasks, max_workers=workers)
+    # W40-#50: --errors 之前解析后从未被引用 ("超过此数将停止"是空话)
+    result = downloader.batch_download(
+        tasks, max_workers=workers, max_errors=errors
+    )
 
     click.echo()
     click.echo(click.style("批量下载完成:", bold=True))
@@ -326,6 +329,13 @@ def download_batch(cli_ctx, file, output, workers, errors, verbose):
         click.style(f"  失败:   {result.failed}", fg="red" if result.failed else None)
     )
     click.echo(f"  成功率: {result.success_rate * 100:.1f}%")
+    if result.metadata and result.metadata.get("aborted"):
+        click.echo(
+            click.style(
+                f"  ⚠ 已中止: 失败数超过 --errors={errors}, 部分任务未执行",
+                fg="yellow",
+            )
+        )
 
     if result.failed > 0:
         sys.exit(1)
@@ -549,6 +559,11 @@ def file_list(cli_ctx, market, type, limit, format):
     if not files:
         click.echo("暂无下载文件")
         return
+
+    # W40-#50: --type 之前解析后从未被引用; 按文件名中的类型关键词过滤
+    if type:
+        kw = type.lower()
+        files = [f for f in files if kw in f["name"].lower()]
 
     # 按修改时间排序
     files.sort(key=lambda x: x["modified"], reverse=True)

--- a/unified_downloader/core/async_downloader.py
+++ b/unified_downloader/core/async_downloader.py
@@ -135,14 +135,34 @@ class AsyncUnifiedDownloader:
             EventType.DOWNLOAD_START, market, code, year, document_type, True
         )
 
-        result = await adapter.async_download(
-            http_client=self._async_http_client,
-            code=code,
-            year=year,
-            document_type=document_type,
-            on_progress=on_progress,
-            **kwargs,
-        )
+        try:
+            result = await adapter.async_download(
+                http_client=self._async_http_client,
+                code=code,
+                year=year,
+                document_type=document_type,
+                on_progress=on_progress,
+                **kwargs,
+            )
+        except Exception as e:
+            # W40-#50: 之前 eu_stock 等骨架的 NotImplementedError 直接抛给
+            # 调用方 (sync 路径却兜成失败结果), 单发/批量两种表现不一致
+            duration_ms = int((time.time() - start_time) * 1000)
+            breaker.record_failure()
+            self._downloader._log_event(
+                EventType.DOWNLOAD_FAILED,
+                market, code, year, document_type,
+                False,
+                error_code="DOWNLOAD_ERROR",
+                error_message=str(e),
+                duration_ms=duration_ms,
+            )
+            return DownloadResult(
+                success=False,
+                error_code="DOWNLOAD_ERROR",
+                error_message=str(e),
+                duration_ms=duration_ms,
+            )
 
         duration_ms = int((time.time() - start_time) * 1000)
         result.duration_ms = duration_ms

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -475,6 +475,7 @@ class UnifiedDownloader:
         self,
         tasks: List[Dict[str, Any]],
         max_workers: Optional[int] = None,
+        max_errors: Optional[int] = None,
         on_task_complete: Optional[Callable[[TaskInfo], None]] = None,
         on_task_progress: Optional[
             Callable[[TaskInfo, ProgressCallbackType], None]
@@ -490,6 +491,8 @@ class UnifiedDownloader:
                    - document_type: 文档类型（可选，默认annual_report）
                    - market: 市场类型（可选，自动识别）
             max_workers: 最大并发数
+            max_errors: 最大失败数, 失败数超过后取消未开始的任务
+                        (None 表示不限制)
             on_task_complete: 任务完成回调
             on_task_progress: 任务进度回调
 
@@ -556,6 +559,7 @@ class UnifiedDownloader:
 
             return result
 
+        aborted = False
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [executor.submit(process_task, task) for task in tasks]
 
@@ -577,6 +581,15 @@ class UnifiedDownloader:
                     )
                     failed += 1
 
+                # W40-#50: 实现 CLI 声明的 --errors 语义 ("超过此数将停止")
+                # — 之前该参数解析后从未被引用。取消尚未开始的任务;
+                # 正在跑的任务让其自然完成。
+                if max_errors is not None and failed > max_errors:
+                    aborted = True
+                    for f in futures:
+                        f.cancel()
+                    break
+
         duration_ms = int((time.time() - start_time) * 1000)
 
         return BatchResult(
@@ -585,6 +598,11 @@ class UnifiedDownloader:
             failed=failed,
             results=results,
             duration_ms=duration_ms,
+            metadata=(
+                {"aborted": True, "aborted_reason": f"max_errors={max_errors} exceeded"}
+                if aborted
+                else None
+            ),
         )
 
     def _detect_market(self, code: str) -> Market:

--- a/unified_downloader/models/entities.py
+++ b/unified_downloader/models/entities.py
@@ -39,6 +39,8 @@ class BatchResult:
     failed: int
     results: List[DownloadResult] = field(default_factory=list)
     duration_ms: Optional[int] = None
+    # W40-#50: 批量提前中止时携带原因 (如 max_errors 超限)
+    metadata: Optional[Dict[str, Any]] = None
 
     @property
     def success_rate(self) -> float:

--- a/unified_downloader/utils/adr_map.py
+++ b/unified_downloader/utils/adr_map.py
@@ -52,7 +52,15 @@ def load_adr_map(path: Optional[Path] = None) -> Dict[str, Any]:
     if not target.exists():
         logger.warning("adr_map.json not found at %s, returning empty map", target)
         return {}
-    return json.loads(target.read_text(encoding="utf-8"))
+    try:
+        return json.loads(target.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        # W40-#50: 损坏的 adr_map.json 之前直接炸掉所有美股 10-K/10-Q
+        # 下载 (get_annual_form_type 调用无保护); 按缺失处理
+        logger.error(
+            "adr_map.json corrupt at %s (%s), returning empty map", target, e
+        )
+        return {}
 
 
 def _us_key_variants(code: str) -> Tuple[str, str, str]:


### PR DESCRIPTION
## 背景

#50 P2 批次的机械可验证项。6-K 季度窗口三项（H1/H2 映射、Q4 跨年搜索、report_period 10q 透传）涉及财报选择行为逻辑，需要真实 SEC 数据验证，**单独成批**不做盲改；translator API key 命令行暴露需确认 babeldoc 传参方式；路径统一归 #49 专项。

## 修复内容

| # | 修复 | 位置 |
|---|---|---|
| 1 | MCP 4 处 market 枚举补 `e`（EU）——专门防回归的一致性测试之前只扫 cli.py，恰好漏掉唯一真漏改的入口；守卫测试扩展为扫 MCP inputSchema + cli.py 全部单字母 Choice | `src/unified_downloader_mcp_server.py` |
| 2 | MCP async handler 里的分钟级同步下载移入 `asyncio.to_thread`（之前冻结 stdio 事件循环，客户端易判超时）；search/years/demo 同样处理 | 同上 |
| 3 | MCP `get_download_status` 的 `Path("data/cache")`/`Path("downloads")` 锚定到仓库根（之前结果取决于进程 CWD） | 同上 |
| 4 | CLI `download batch --errors` 之前声明"超过此数将停止"但解析后从未引用——现在真实接入 `batch_download(max_errors=)`：失败超限取消未开始的任务并在输出提示；`file list --type` 同样从死参数变为按文件名类型过滤 | `cli.py` + `downloader.py` |
| 5 | `_primary_doc_ext()`：`.endswith(".htm")` 漏判 `.html`（文件被存 `.txt` 且跳过图片内嵌/PDF 转换）；`" exhibit" in link` 是死条件（URL 空格编码为 `%20`）改判 `%20exhibit` | `m_stock.py` |
| 6 | `_search_filings` 常态路径（edgar 成功）不再连等两个限速 key——为从未发生的 sec-api 调用白睡 ~5s/次，批量下显著拖慢 | `m_stock.py` |
| 7 | `adr_map.json` 损坏按缺失处理（之前 `json.loads` 无保护，直接炸掉所有美股 10-K/10-Q 下载） | `adr_map.py` |
| 8 | `a_stock` PDF_BASE_URL http→https（与同文件全文检索 URL 统一） | `a_stock.py` |
| 9 | `async_downloader` 对 adapter 异常兜成 `DOWNLOAD_ERROR`（eu_stock 骨架的 NotImplementedError 之前单发直接抛给调用方，与 sync 表现不一致） | `async_downloader.py` |
| 10 | pyproject `python ^3.9 → ^3.10`；`BatchResult` 加 `metadata` 携带批量中止原因 | `pyproject.toml` 等 |

## 测试

新增 `test_p2_polish.py` **15 用例**（MCP/CLI 枚举一致性守卫、ext 判定、adr_map 容错、限速单 key、eu async 一致性、max_errors 中止）；全量 **223 passed**。

Refs #50（P2 机械项勾选）