### PR TITLE
fix(6k): 季度窗口三项修复 — H1/H2 映射、Q4 跨年搜索、10q 透传（真实 SEC 数据验证）

### DIFF
--- a/tests/test_6k_window_cross_year.py
+++ b/tests/test_6k_window_cross_year.py
@@ -1,0 +1,224 @@
+"""
+Regression tests for 6-K 季度窗口三项修复 (W40-#50 P2).
+
+1. H1/H2 半年报之前按 Q1/Q2 映射 month_end (H1→3-31, H2→6-30), 窗口错
+   一个季度 — RACE 等 7 月底发布的中报完全落在窗口外
+2. Q4/FY 财报发布窗口在次年 1-3 月, 搜索层按日历年过滤提前丢弃 →
+   窗口逻辑对 Q4 永远空转 (include_next_year)
+3. report_period 在 10q (FPI→6-K) 路径被 **kwargs 静默吞掉
+
+这些测试只测选择/传参逻辑, 不下载真实文件 (真实 SEC 验证见 PR 描述).
+"""
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import (  # noqa: E402
+    MStockAdapter,
+    _report_period_target_end,
+)
+
+
+def _mk_filing(accession: str, size: int, filed_at: str, exhibits=None):
+    return {
+        "ticker": "TEST",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "1",
+        "companyName": accession,
+        "linkToTxt": f"https://example.com/{accession}",
+        "linkToHtml": f"https://example.com/{accession}",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits or [],
+    }
+
+
+@pytest.fixture
+def adapter():
+    return MStockAdapter(MagicMock(), [])
+
+
+# ═══ 1. H1/H2 映射 ═══
+
+
+class TestReportPeriodTargetEnd:
+    def test_quarters(self):
+        assert _report_period_target_end("2026Q1") == date(2026, 3, 31)
+        assert _report_period_target_end("2026Q2") == date(2026, 6, 30)
+        assert _report_period_target_end("2026Q3") == date(2026, 9, 30)
+        assert _report_period_target_end("2026Q4") == date(2026, 12, 31)
+
+    def test_half_year_fixed(self):
+        # 回归核心: 之前 H1→3-31 / H2→6-30 (按 Q1/Q2 映射), 错一个季度
+        assert _report_period_target_end("2026H1") == date(2026, 6, 30)
+        assert _report_period_target_end("2026H2") == date(2026, 12, 31)
+
+    def test_invalid_half_year(self):
+        assert _report_period_target_end("2026H3") is None
+        assert _report_period_target_end("2026H4") is None
+
+    def test_fy_and_garbage(self):
+        assert _report_period_target_end("2026FY") == date(2026, 12, 31)
+        assert _report_period_target_end("2026") == date(2026, 12, 31)
+        assert _report_period_target_end("nonsense") is None
+        assert _report_period_target_end(None) is None
+
+    def test_lowercase_input(self):
+        assert _report_period_target_end("2026h1") == date(2026, 6, 30)
+
+
+class TestHalfYearWindow:
+    def test_h1_window_catches_july_interim(self, adapter):
+        """RACE 式 H1 中报 7-30 发布 — 修复前窗口 4-25~6-24 落空"""
+        filings = [
+            _mk_filing("PR-JUN", 50000, "2026-06-20"),     # 窗口外噪音
+            _mk_filing("INTERIM-H1", 209000, "2026-07-30",
+                       exhibits=[{"url": "https://x/a.htm",
+                                  "description": "Interim report EXHIBIT 99.1",
+                                  "document": "tm1_ex99-1.htm"}]),
+        ]
+
+        picked = adapter._pick_earnings_6k(filings, report_period="2026H1")
+
+        assert picked is not None
+        assert picked["accessionNo"] == "INTERIM-H1"
+
+
+# ═══ 2. Q4 跨年搜索 ═══
+
+
+class TestQ4CrossYear:
+    def test_q4_window_picks_next_january_filing(self, adapter):
+        """2025Q4 财报 2026-02 发布 — 修复前搜索层把它过滤掉"""
+        filings = [
+            _mk_filing("Q4-EARNINGS", 400000, "2026-02-10",
+                       exhibits=[{"url": "https://x/q4.htm",
+                                  "description": "Fourth quarter results",
+                                  "document": "tm2_ex99-1.htm"}]),
+            _mk_filing("OLD-PR", 30000, "2025-03-15"),
+        ]
+
+        picked = adapter._pick_earnings_6k(filings, report_period="2025Q4")
+
+        assert picked is not None
+        assert picked["accessionNo"] == "Q4-EARNINGS"
+
+    def test_download_form_passes_include_next_year_for_q4(self, adapter):
+        """_download_form 对 Q4/FY/H2 的 6-K 搜索要放行次年 filing"""
+        captured = {}
+
+        def fake_search(ticker, form_type, year, size=10, include_next_year=False):
+            captured["include_next_year"] = include_next_year
+            return [_mk_filing("Q4", 400000, "2026-02-10")]
+
+        ok_result = MagicMock()
+        ok_result.success = True
+        with patch.object(adapter, "_search_filings", side_effect=fake_search), \
+             patch.object(adapter, "_download_filing", return_value=ok_result):
+            adapter._download_form(
+                "TEST", "6-K", 2025, None, None, report_period="2025Q4"
+            )
+
+        assert captured["include_next_year"] is True
+
+    def test_download_form_no_flag_for_q2(self, adapter):
+        captured = {}
+
+        def fake_search(ticker, form_type, year, size=10, include_next_year=False):
+            captured["include_next_year"] = include_next_year
+            return [_mk_filing("Q2", 200000, "2025-08-13")]
+
+        ok_result = MagicMock()
+        ok_result.success = True
+        with patch.object(adapter, "_search_filings", side_effect=fake_search), \
+             patch.object(adapter, "_download_filing", return_value=ok_result):
+            adapter._download_form(
+                "TEST", "6-K", 2025, None, None, report_period="2025Q2"
+            )
+
+        assert captured["include_next_year"] is False
+
+    def test_download_form_no_flag_without_report_period(self, adapter):
+        captured = {}
+
+        def fake_search(ticker, form_type, year, size=10, include_next_year=False):
+            captured["include_next_year"] = include_next_year
+            return [_mk_filing("X", 1000, "2025-05-01")]
+
+        ok_result = MagicMock()
+        ok_result.success = True
+        with patch.object(adapter, "_search_filings", side_effect=fake_search), \
+             patch.object(adapter, "_download_filing", return_value=ok_result):
+            adapter._download_form("TEST", "6-K", 2025, None, None)
+
+        assert captured["include_next_year"] is False
+
+    def test_sec_api_query_spans_next_year(self, adapter):
+        adapter._api_key = "test-key"
+        captured = {}
+
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"filings": []}
+
+        def fake_post(url, json=None, headers=None):
+            captured["payload"] = json
+            return FakeResp()
+
+        with patch.object(adapter._http_client, "post", side_effect=fake_post), \
+             patch.object(adapter, "_get_datasource", return_value=None):
+            adapter._search_sec_api(
+                "TEST", "6-K", 2025, size=10, include_next_year=True
+            )
+            query = captured["payload"]["query"]["query_string"]["query"]
+            # 上界收到次年 6-30: filings 新→旧返回 + size 截断, 上界太宽
+            # 会让次年后半年淹没 Q4 发布窗口 (TSM 2024Q4 真实数据验证)
+            assert "filedAt:[2025-01-01 TO 2026-06-30]" in query
+
+            adapter._search_sec_api("TEST", "6-K", 2025, size=10)
+            query2 = captured["payload"]["query"]["query_string"]["query"]
+            assert "filedAt:[2025-01-01 TO 2025-12-31]" in query2
+
+
+# ═══ 3. 10q 入口 report_period 透传 ═══
+
+
+class TestTenQReportPeriodPassthrough:
+    def test_10q_forwards_report_period_to_form(self, adapter):
+        """FPI 公司 10q → 6-K: report_period 之前被 **kwargs 吞掉"""
+        captured = {}
+
+        def fake_form(code, form_type, year, checkpoint, on_progress,
+                      report_period=None):
+            captured["form_type"] = form_type
+            captured["report_period"] = report_period
+            return MagicMock(success=True)
+
+        with patch.object(
+            adapter, "get_quarterly_form_type", return_value="6-K"
+        ), patch.object(adapter, "_download_form", side_effect=fake_form):
+            adapter._download_10q(
+                "XNET", 2026, None, None, None, report_period="2026Q2"
+            )
+
+        assert captured["form_type"] == "6-K"
+        assert captured["report_period"] == "2026Q2"
+
+    def test_10q_without_report_period_still_works(self, adapter):
+        with patch.object(
+            adapter, "get_quarterly_form_type", return_value="10-Q"
+        ), patch.object(adapter, "_download_form") as mock_form:
+            mock_form.return_value = MagicMock(success=True)
+            adapter._download_10q("AAPL", 2026, None, None, None)
+
+        mock_form.assert_called_once()
+        assert mock_form.call_args.kwargs.get("report_period") is None

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -27,6 +27,37 @@ from unified_downloader.exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def _report_period_target_end(report_period):
+    """report_period ('2026Q2'/'2026H1'/'2026FY') → 目标报告期结束日.
+
+    W40-#50: 之前 H1/H2 半年报按 Q1/Q2 映射 month_end (H1→3-31, H2→6-30),
+    窗口错一个季度 — RACE 等公司 7 月底发布的中报完全落在窗口外;
+    H3/H4 无意义, 返回 None.
+    """
+    if not report_period:
+        return None
+    try:
+        period = str(report_period).upper()  # e.g. 2026Q2 / 2026FY / 2026H1
+        m = re.match(r"(\d{4})(?:([QH])([1-4])|FY)?$", period)
+        if not m:
+            return None
+        y = int(m.group(1))
+        kind, idx = m.group(2), m.group(3)
+        if not idx:
+            return datetime.date(y, 12, 31)  # FY 无明确季度 → 12-31
+        if kind == "H":
+            if idx not in ("1", "2"):
+                return None
+            month_end = 6 if idx == "1" else 12
+        else:
+            month_end = {"1": 3, "2": 6, "3": 9, "4": 12}[idx]
+        # off-by-1 修复 (PR #48 review 8-14): 不能硬编码 day=30
+        last_day = calendar.monthrange(y, month_end)[1]
+        return datetime.date(y, month_end, last_day)
+    except Exception:
+        return None
+
+
 def _primary_doc_ext(link: str) -> str:
     """primary doc 链接 → 保存扩展名。
 
@@ -229,6 +260,7 @@ class MStockAdapter(BaseStockAdapter):
         form_type: str,
         year: Optional[int],
         size: int = 10,
+        include_next_year: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         使用edgartools搜索SEC filings
@@ -259,7 +291,20 @@ class MStockAdapter(BaseStockAdapter):
                 if year:
                     try:
                         filing_year = filing.filing_date.year
-                        if filing_year != year:
+                        # W40-#50: Q4/FY 财报的发布窗口在次年 1-3 月,
+                        # 之前按日历年过滤把这些 filing 提前丢掉 →
+                        # _pick_earnings_6k 的窗口对 Q4 永远空转。
+                        # 真实数据验证 (TSM 2024Q4): filings 新→旧返回且
+                        # size 截断, 只放宽年份会让次年后半年淹没结果 —
+                        # 上界收到次年 6-30, 恰好覆盖发布窗口
+                        allowed = {year, year + 1} if include_next_year else {year}
+                        if filing_year not in allowed:
+                            continue
+                        if (
+                            include_next_year
+                            and filing_year == year + 1
+                            and filing.filing_date.month > 6
+                        ):
                             continue
                     except (ValueError, IndexError):
                         pass
@@ -334,6 +379,7 @@ class MStockAdapter(BaseStockAdapter):
         form_type: str,
         year: Optional[int],
         size: int = 10,
+        include_next_year: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         使用sec-api搜索SEC filings
@@ -356,7 +402,12 @@ class MStockAdapter(BaseStockAdapter):
             parts.append(f'formType:"{form_type}"')
         if year:
             date_from = f"{year}-01-01"
-            date_to = f"{year}-12-31"
+            # W40-#50: Q4/FY 窗口跨年 — 扩到次年但上界收 6-30 (与新→旧
+            # 返回 + size 截断的 edgar 行为对齐, 防次年后半年淹没窗口)
+            if include_next_year:
+                date_to = f"{year + 1}-06-30"
+            else:
+                date_to = f"{year}-12-31"
             parts.append(f"filedAt:[{date_from} TO {date_to}]")
 
         query = {"query_string": {"query": " AND ".join(parts)}}
@@ -392,6 +443,7 @@ class MStockAdapter(BaseStockAdapter):
         form_type: str,
         year: Optional[int],
         size: int = 10,
+        include_next_year: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         搜索SEC filings (优先edgartools，失败则sec-api)
@@ -418,7 +470,10 @@ class MStockAdapter(BaseStockAdapter):
                 _dt_init = time.monotonic() - _t_init
                 if init_ok:
                     _t_edgar = time.monotonic()
-                    results = self._search_edgar(ticker, form_type, year, size)
+                    results = self._search_edgar(
+                        ticker, form_type, year, size,
+                        include_next_year=include_next_year,
+                    )
                     _dt_edgar = time.monotonic() - _t_edgar
                     logger.info(
                         f"[m_stock timing] search edgar ok: ticker={ticker} form={form_type} "
@@ -440,7 +495,10 @@ class MStockAdapter(BaseStockAdapter):
             self._rate_limiter.wait("sec_api_search")
             for attempt in range(self.MAX_RETRIES):
                 try:
-                    return self._search_sec_api(ticker, form_type, year, size)
+                    return self._search_sec_api(
+                        ticker, form_type, year, size,
+                        include_next_year=include_next_year,
+                    )
                 except Exception as e:
                     last_error = e
                     logger.warning(
@@ -511,7 +569,19 @@ class MStockAdapter(BaseStockAdapter):
             # (如 RACE 7-31 fnvbb310726prex.htm 3KB), 而非 Q2 财报 (7-30 interim report
             # 209KB 含 revenue/EBITDA). 所以对 6-K 多取几条, 选 exhibit 含财报关键词的.
             size = 10 if form_type == "6-K" else 1
-            filings = self._search_filings(ticker, form_type, year, size=size)
+            # W40-#50: Q4/FY/H2 的财报窗口落在次年 1~3 月 — 搜索层要允许
+            # 次年 filing, 否则窗口逻辑永远空转、回退 size 启发式选错文档
+            _target_end = _report_period_target_end(report_period)
+            include_next_year = bool(
+                form_type == "6-K"
+                and year is not None
+                and _target_end is not None
+                and _target_end.month == 12
+            )
+            filings = self._search_filings(
+                ticker, form_type, year, size=size,
+                include_next_year=include_next_year,
+            )
 
             if not filings:
                 return _try_ir_fallback()
@@ -601,29 +671,14 @@ class MStockAdapter(BaseStockAdapter):
         2. 无 report_period 或窗口无命中 → 回退旧逻辑 (打分 → None).
         """
         # 目标季度窗口 (季度结束后第 N~M 天发布财报)
-        QUARTER_EARLY_DAYS = 25   # 财报最早可能在季度结束后 ~25 天发布
+        # W40-#50 真实数据验证 (TSM): Q4 财报最早 ~16 天就发布 (次年 1 月
+        # 中旬), 25 天会漏; 14 天与相邻季度窗口 (Q3 止 12-24) 仍无重叠
+        QUARTER_EARLY_DAYS = 14
         QUARTER_LATE_DAYS = 85    # 最晚在 ~85 天内 (跨季末但未到下一季末)
 
-        # 解析 report_period → 目标季度结束日
-        target_end: Optional[datetime.date] = None
-        if report_period:
-            try:
-                period = report_period.upper()  # e.g. 2026Q2 / 2026FY / 2026H1
-                m = re.match(r"(\d{4})(?:[QH]([1-4]))?", period)
-                if m:
-                    y = int(m.group(1))
-                    q = m.group(2)
-                    if q:
-                        month_end = {"1": 3, "2": 6, "3": 9, "4": 12}[q]
-                        # off-by-1 修复 (PR #48 review 8-14): 3月=31天, 12月=31天,
-                        # 不能硬编码 day=30 (Q1 会得 Mar30 而非 Mar31, Q4 得 Dec30 而非 Dec31)
-                        last_day = calendar.monthrange(y, month_end)[1]
-                        target_end = datetime.date(y, month_end, last_day)
-                    else:
-                        # FY 无明确季度 → 用 12-31 (年度报告)
-                        target_end = datetime.date(y, 12, 31)
-            except Exception:
-                target_end = None
+        # 解析 report_period → 目标报告期结束日 (W40-#50: 抽出共用 helper,
+        # 同步修复 H1/H2 按季度映射错一个季度的 bug)
+        target_end = _report_period_target_end(report_period)
 
         def _filed_at_date(f: Dict[str, Any]) -> Optional[datetime.date]:
             raw = f.get("filedAt") or f.get("filing_date") or ""
@@ -925,7 +980,17 @@ class MStockAdapter(BaseStockAdapter):
     ) -> DownloadResult:
         """下载季度报告：外国私人发行人(FPI)使用6-K，美国本土公司使用10-Q"""
         form_type = self.get_quarterly_form_type(code)
-        return self._download_form(code, form_type, year, checkpoint, on_progress)
+        # W40-#50: report_period 之前被 **kwargs 吞掉 — FPI 公司 (NVO/XNET)
+        # 走 6-K 时季度窗口完全不生效, "10q 入口选错季度" 复现
+        report_period = kwargs.get("report_period")
+        if report_period and form_type == "6-K":
+            logger.info(
+                f"{code} quarterly→6-K, report_period={report_period} 季度窗口生效"
+            )
+        return self._download_form(
+            code, form_type, year, checkpoint, on_progress,
+            report_period=report_period,
+        )
 
     def get_quarterly_form_type(self, code: str) -> str:
         """判断公司的季度报告SEC归档表格类型。


### PR DESCRIPTION
## 背景

#50 剩余项中最重的一批。当初有意推迟：涉及财报选择**行为逻辑**，需真实 SEC 数据验证才能改——这个决定在本批被证明是对的（见下）。

## 修复内容

### 1. H1/H2 半年报映射错一个季度
`_pick_earnings_6k` 把 H1/H2 按 Q1/Q2 映射 month_end（H1→3-31、H2→6-30），窗口整体错一个季度——RACE 等公司 7 月底发布的中报完全落在窗口外，docstring 声称支持 `2026H1` 实际不可用。
抽出共用 helper `_report_period_target_end()`：H1→6-30、H2→12-31、H3/H4 返回 None、支持 FY 后缀。`_download_form` 与 `_pick_earnings_6k` 共用。

### 2. Q4/FY 窗口被日历年过滤提前丢弃
Q4/FY/H2 财报的合法发布窗口在**次年 1-3 月**，但搜索层 `filing_year != year` 把它们全部过滤——窗口逻辑对 Q4 永远空转，回退 size 启发式选错文档。三层搜索（edgar/sec-api/filings）增加 `include_next_year`，`_download_form` 对 Q4/FY/H2 的 6-K 自动启用。

### 3. report_period 在 10q 路径被吞
FPI 公司（NVO/XNET）`-t 10q` 走 6-K，但 `_download_10q` 的 `**kwargs` 把 `report_period` 静默吞掉——XNET 式"选错季度"在 10q 入口完整复现。现在透传给 `_download_form`。

## 真实 SEC 验证（TSM 2024Q4）——首版实现被推翻两次

这正是当初不盲改的原因。首版`include_next_year`实现上线验证即发现两个新缺陷：

| 首版假设 | 真实数据 | 修正 |
|---|---|---|
| 放宽年份过滤即可 | filings 按**新→旧**返回且 `size=30` 截断，次年后半年（6-12月）的 filing 淹没结果，1-3 月窗口的 Q4 财报**根本进不了列表**（实测选中 2025-11 的其他季度文档） | 上界收到次年 **6-30**，恰好覆盖发布窗口 |
| 财报最早季度结束 +25 天发布 | TSM 的 Q4 财报 **1 月中旬（~16 天）** 就发布，25 天起点会漏 | `QUARTER_EARLY_DAYS` 25→**14**（与相邻季度窗口 12-24 仍无重叠） |

修正后复验：TSM 2024Q4 搜索可见次年 1-3 月 **14 条** filing，窗口选中 **2025-02-27 的 19.6MB Q4 完整财报**（修复前选中 2025-11 错误季度文档，更早版本则完全漏掉）。

## 测试

新增 `test_6k_window_cross_year.py` **13 用例**（H1/H2 边界、H1 窗口命中 7 月中报、Q4 窗口命中次年 filing、include_next_year 三分支、sec-api 查询范围、10q 透传）；全量 **236 passed**。

Refs #50（6-K 窗口三项勾选）