### PR TITLE
feat(#49): 下载路径统一 — 缓存层记住语义路径，命中零还原零网络

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,3 +285,26 @@ unified-downloader/
 ├── pyproject.toml             # Poetry 项目配置
 └── README.md
 ```
+
+## 下载路径与缓存规范（#49）
+
+所有市场的下载文件统一遵循一套语义化路径规范，`DownloadResult.file_path` 永远返回语义路径（不是缓存 hash 路径）：
+
+```
+downloads/{market}/{code_prefix}/{CODE}_{YYYY}_{LABEL}{ext}
+```
+
+- `market`：`a`=A股 / `h`=港股 / `m`=美股 / `e`=EU
+- `code_prefix`：代码前 3 位（A股补零到 6 位后取前 3；港股补零到 5 位后取前 3）
+- `LABEL`：与市场派发一致的文档类型标签（如 `ANNUAL_REPORT` / `INTERIM_REPORT` / `QUARTERLY_REPORT` / `PROSPECTUS`；美股为 SEC form 如 `10K` / `10Q` / `6K` / `20F`）
+- A股扩展名固定 `.PDF`；港股 `.pdf`/`.html` 由原始链接决定；美股 `.html`（`--pdf` 时 `.pdf`）
+
+缓存是双层结构：
+
+- **持久层**：`data/cache/{market}/{code_prefix}/{md5}{ext}`（hash 文件名，SQLite `cache_entries` 表管理 TTL/LRU）
+- **语义视图**：`downloads/` 下的语义路径。缓存命中时优先返回 `cache_entries.semantic_path`（首次下载时记录）；老条目或语义副本被清理时，从 hash 副本按上述命名规则本地还原（**零网络请求**），并懒回填
+
+注意：
+- 路径按**相对形态**存储，请从项目根目录运行
+- `metadata["cache_path"]` 恒为 hash 持久层路径（诊断用）
+- 历史数据库中的旧 hash 路径记录不做本仓库侧迁移（见 issue #49 任务 B4，由下游 morning-brief/服务器处理）

--- a/tests/test_cache_semantic_path.py
+++ b/tests/test_cache_semantic_path.py
@@ -1,0 +1,251 @@
+"""
+Regression tests for #49 路径统一专项 (W40-#49).
+
+核心行为:
+1. 缓存层记住语义路径 — 新条目命中直接返回 downloads/ 路径, 零还原零网络
+   (此前美股每次命中调 edgar.Company() 发 SEC 请求, A/H 直接返回
+   data/cache hash 乱码路径 → morning-brief DB file_path 不统一的根因)
+2. 老条目 (无 semantic_path) / 语义副本被清理 → 从 hash 副本还原;
+   A/H 用 adapter 复刻下载命名的本地推导, 无网络
+3. 老库 schema 迁移 (ALTER TABLE 加列)
+4. put 的防御: 入参是缓存路径时不写坏 semantic_path
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from unified_downloader.infra.cache import CacheManager, CacheHit  # noqa: E402
+
+
+def _make_pdf(path: Path, size: int = 2048) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF-1.4\n" + b"x" * size)
+    return path
+
+
+# ═══ 老库 schema 迁移 ═══
+
+
+class TestSchemaMigration:
+    def test_old_db_gets_semantic_path_column(self, tmp_path):
+        """手工建 8 列老 schema → CacheManager 初始化 → 列补齐、老行可读"""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        db = cache_dir / ".cache.db"
+        with sqlite3.connect(str(db)) as conn:
+            conn.execute("""
+                CREATE TABLE cache_entries (
+                    key TEXT PRIMARY KEY, file_path TEXT NOT NULL,
+                    size INTEGER NOT NULL, created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL, md5 TEXT,
+                    access_count INTEGER DEFAULT 0, last_access TEXT
+                )
+            """)
+            old_hash = cache_dir / "a" / "600" / "abc123.PDF"
+            _make_pdf(old_hash)
+            conn.execute(
+                "INSERT INTO cache_entries (key, file_path, size, created_at,"
+                " expires_at) VALUES (?, ?, ?, ?, ?)",
+                ("k1", str(old_hash), 100, "2026-08-01T00:00:00",
+                 "2099-01-01T00:00:00"),
+            )
+
+        mgr = CacheManager(cache_dir)  # 触发迁移
+
+        with sqlite3.connect(str(db)) as conn:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(cache_entries)")}
+        assert "semantic_path" in cols
+
+        hit = mgr.get("a", "OLD", None, "annual_report") if False else None
+        # 老行直接按 key 读 (不走 _make_key, 用 db 查)
+        with sqlite3.connect(str(db)) as conn:
+            row = conn.execute(
+                "SELECT file_path, semantic_path FROM cache_entries WHERE key='k1'"
+            ).fetchone()
+        assert row[0].endswith("abc123.PDF")
+        assert row[1] is None  # 老行 semantic 为 NULL → 走还原
+
+
+# ═══ CacheHit / put 防御 ═══
+
+
+class TestCacheHitSemantics:
+    def test_put_stores_semantic_path_and_get_returns_it(self, tmp_path):
+        mgr = CacheManager(tmp_path / "cache")
+        semantic = _make_pdf(tmp_path / "downloads" / "a" / "600" / "600519_2025_ANNUAL_REPORT.PDF")
+
+        mgr.put("a", "600519", 2025, "annual_report", file_path=semantic)
+
+        hit = mgr.get("a", "600519", 2025, "annual_report")
+        assert isinstance(hit, CacheHit)
+        assert hit.semantic_path == str(semantic)
+        assert hit.path == str(semantic)          # 直接语义, 不走还原
+        assert hit.hash_path.startswith(str(tmp_path / "cache"))
+
+    def test_semantic_copy_deleted_hash_alive_still_hits(self, tmp_path):
+        """语义副本 (downloads/) 被清理 → 不删条目, 返回 hash 路径由调用方还原"""
+        mgr = CacheManager(tmp_path / "cache")
+        semantic = _make_pdf(tmp_path / "downloads" / "a" / "600" / "600519_2025_ANNUAL_REPORT.PDF")
+        mgr.put("a", "600519", 2025, "annual_report", file_path=semantic)
+        semantic.unlink()  # 用户清理了 downloads/
+
+        hit = mgr.get("a", "600519", 2025, "annual_report")
+        assert hit is not None                     # hash 副本健在 → 条目有效
+        assert hit.semantic_path is None           # 语义副本丢了
+        assert hit.path == hit.hash_path           # 调用方走还原
+
+    def test_put_with_cache_path_input_keeps_old_semantic(self, tmp_path):
+        """V5 防御: 入参本身是缓存路径时不写坏 semantic_path"""
+        mgr = CacheManager(tmp_path / "cache")
+        semantic = _make_pdf(tmp_path / "downloads" / "m" / "AAP" / "AAPL_2025_10K.html")
+        mgr.put("m", "AAPL", 2025, "10k", file_path=semantic)
+        hit1 = mgr.get("m", "AAPL", 2025, "10k")
+        assert hit1.semantic_path == str(semantic)
+
+        # 用 hash 副本路径再次 put (理论调用路径) — 不得覆盖 semantic
+        mgr.put("m", "AAPL", 2025, "10k", file_path=Path(hit1.hash_path))
+
+        hit2 = mgr.get("m", "AAPL", 2025, "10k")
+        assert hit2.semantic_path == str(semantic)
+
+    def test_set_semantic_path_backfill(self, tmp_path):
+        mgr = CacheManager(tmp_path / "cache")
+        semantic = _make_pdf(tmp_path / "downloads" / "h" / "007" / "00700_2025_ANNUAL_REPORT.pdf")
+        mgr.put("h", "00700", 2025, "annual_report", file_path=semantic)
+        with sqlite3.connect(str(mgr._db_path)) as conn:
+            conn.execute("UPDATE cache_entries SET semantic_path = NULL")
+
+        mgr.set_semantic_path("h", "00700", 2025, "annual_report", str(semantic))
+
+        hit = mgr.get("h", "00700", 2025, "annual_report")
+        assert hit.semantic_path == str(semantic)
+
+
+# ═══ adapter 推导矩阵 (A/H 老条目还原依据) ═══
+
+
+class TestAdapterSemanticDerivation:
+    def test_a_stock_code_normalization(self):
+        from unified_downloader.adapters.a_stock import AStockAdapter
+
+        adapter = AStockAdapter(MagicMock(), [])
+        p1 = adapter.build_semantic_cache_path("600519", 2025, "annual_report", ".PDF")
+        p2 = adapter.build_semantic_cache_path("sh600519", 2025, "annual_report", ".PDF")
+        assert p1 == p2 == Path("downloads/a/600/600519_2025_ANNUAL_REPORT.PDF")
+
+    def test_a_stock_label_dispatch(self):
+        from unified_downloader.adapters.a_stock import AStockAdapter
+
+        adapter = AStockAdapter(MagicMock(), [])
+        q1 = adapter.build_semantic_cache_path("600519", 2025, "quarterly_q1", ".PDF")
+        unknown = adapter.build_semantic_cache_path("600519", 2025, "bogus", ".PDF")
+        assert q1.name == "600519_2025_QUARTERLY_REPORT.PDF"   # q1 → QUARTERLY_REPORT
+        assert unknown.name == "600519_2025_ANNUAL_REPORT.PDF"  # 未知 → 年报 (与 download 一致)
+
+    def test_a_stock_year_none_no_year_in_name(self):
+        from unified_downloader.adapters.a_stock import AStockAdapter
+
+        adapter = AStockAdapter(MagicMock(), [])
+        p = adapter.build_semantic_cache_path("600519", None, "prospectus", ".PDF")
+        assert p.name == "600519_PROSPECTUS.PDF"
+
+    def test_h_stock_zfill5_and_ext(self):
+        from unified_downloader.adapters.h_stock import HStockAdapter
+
+        adapter = HStockAdapter(MagicMock(), [])
+        p1 = adapter.build_semantic_cache_path("700", 2025, "annual_report", ".pdf")
+        p2 = adapter.build_semantic_cache_path("00700", 2025, "annual_report", ".pdf")
+        assert p1 == p2 == Path("downloads/h/007/00700_2025_ANNUAL_REPORT.pdf")
+
+    def test_base_default_raises(self):
+        from unified_downloader.adapters.base import BaseStockAdapter
+
+        # 最小具体子类 (实现两个抽象方法), 验证 base 默认实现
+        Dummy = type(
+            "DummyAdapter",
+            (BaseStockAdapter,),
+            {
+                "__init__": lambda self: None,
+                "download": lambda self, *a, **k: None,
+                "async_download": lambda self, *a, **k: None,
+            },
+        )
+        with pytest.raises(NotImplementedError):
+            Dummy().build_semantic_cache_path("X", 2025, "annual_report", ".pdf")
+
+
+# ═══ downloader 级: 命中路径 / 零网络 ═══
+
+
+@pytest.fixture
+def downloader(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from unified_downloader.core.downloader import UnifiedDownloader
+    from unified_downloader.core.config import get_default_config
+
+    d = UnifiedDownloader(get_default_config())
+    yield d
+    d.close()
+
+
+class TestDownloaderSemanticCacheHit:
+    def test_us_second_hit_zero_network(self, downloader, tmp_path):
+        """新条目二次命中: 不调 get_annual_form_type (之前每次命中打 SEC)"""
+        from unified_downloader.adapters.m_stock import MStockAdapter
+        from unified_downloader.models.enums import Market
+        from unified_downloader.models.entities import DownloadResult
+
+        out = _make_html(tmp_path / "downloads" / "m" / "AAP" / "AAPL_2025_10K.html")
+        adapter = downloader._adapters[Market.M]
+        adapter.download = MagicMock(return_value=DownloadResult(
+            success=True, file_path=str(out), file_size=out.stat().st_size, source="edgar"))
+
+        r1 = downloader.download("AAPL", 2025, "10k", market=Market.M)
+        assert r1.success
+
+        with patch.object(
+            MStockAdapter, "get_annual_form_type",
+            side_effect=AssertionError("cache hit must not hit SEC"),
+        ):
+            r2 = downloader.download("AAPL", 2025, "10k", market=Market.M)
+
+        assert r2.cached is True
+        assert Path(r2.file_path) == out
+        assert r2.metadata["cache_path"].startswith("data/cache/m/AAP/")  # 契约: 恒 hash 路径
+
+    def test_ah_old_entry_restored_to_semantic_not_hash(self, downloader, tmp_path):
+        """#49 核心: A 股老条目 (无 semantic) 命中 → 返回语义路径而非 hash 乱码"""
+        from unified_downloader.models.enums import Market
+
+        semantic = _make_pdf(
+            tmp_path / "downloads" / "a" / "600" / "600519_2025_ANNUAL_REPORT.PDF")
+        downloader._cache_manager.put(
+            "a", "600519", 2025, "annual_report", file_path=semantic)
+        with sqlite3.connect(str(downloader._cache_manager._db_path)) as conn:
+            conn.execute("UPDATE cache_entries SET semantic_path = NULL")
+        semantic.unlink()  # 语义副本不存在, hash 副本在
+
+        r = downloader.download("600519", 2025, "annual_report", market=Market.A)
+
+        assert r.success and r.cached
+        assert not str(r.file_path).startswith("data/cache"), "不得返回 hash 乱码路径"
+        assert Path(r.file_path).name == "600519_2025_ANNUAL_REPORT.PDF"
+        assert Path(r.file_path).exists()          # hash 副本已复制还原
+
+        # 第二次命中: 已懒回填 → 直接语义路径
+        r2 = downloader.download("600519", 2025, "annual_report", market=Market.A)
+        assert r2.file_path == r.file_path
+
+
+def _make_html(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"<html>" + b"y" * 2048 + b"</html>")
+    return path

--- a/unified_downloader/adapters/a_stock.py
+++ b/unified_downloader/adapters/a_stock.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import urllib.parse
+from pathlib import Path
 from datetime import date
 from typing import Optional, List, Dict, Any, Callable
 
@@ -293,6 +294,37 @@ class AStockAdapter(BaseStockAdapter):
             checkpoint,
             on_progress,
         )
+
+    # W40-#49: doc_type → 文件名 label, 与 download() 分发一致
+    # (quarterly_q1/q3/quarterly 都是 quarterly_report; 未知类型按年报,
+    # 同 download() 的 else 分支)
+    _SEMANTIC_LABELS = {
+        "annual_report": "ANNUAL_REPORT", "年报": "ANNUAL_REPORT",
+        "年度报告": "ANNUAL_REPORT",
+        "interim_report": "INTERIM_REPORT", "中期报告": "INTERIM_REPORT",
+        "半年报": "INTERIM_REPORT",
+        "quarterly_q1": "QUARTERLY_REPORT", "q1": "QUARTERLY_REPORT",
+        "一季报": "QUARTERLY_REPORT",
+        "quarterly_q3": "QUARTERLY_REPORT", "q3": "QUARTERLY_REPORT",
+        "三季报": "QUARTERLY_REPORT",
+        "quarterly": "QUARTERLY_REPORT", "季度": "QUARTERLY_REPORT",
+        "prospectus": "PROSPECTUS", "招股说明书": "PROSPECTUS",
+        "招股书": "PROSPECTUS", "s1": "PROSPECTUS",
+    }
+
+    def build_semantic_cache_path(
+        self, code: str, year: Optional[int], document_type: str, ext: str
+    ) -> Path:
+        """W40-#49: 复刻 A 股下载命名 — 去 SH/SZ 前缀 + zfill(6),
+        扩展名固定大写 .PDF (A 股公告全部是 PDF)"""
+        symbol = code.strip().upper()
+        if symbol.startswith(("SH", "SZ")):
+            symbol = symbol[2:]
+        symbol = symbol.zfill(6)
+        label = self._SEMANTIC_LABELS.get(
+            str(document_type).lower(), "ANNUAL_REPORT"
+        )
+        return self._build_file_path(symbol, year, label, ".PDF")
 
     def _download_annual_report(
         self,

--- a/unified_downloader/adapters/base.py
+++ b/unified_downloader/adapters/base.py
@@ -69,6 +69,24 @@ class BaseStockAdapter(ABC):
                 return ds
         return None
 
+    def build_semantic_cache_path(
+        self,
+        code: str,
+        year: Optional[int],
+        document_type: str,
+        ext: str,
+    ) -> Path:
+        """语义缓存路径推导 (W40-#49).
+
+        缓存老条目 (无 semantic_path) 或 downloads/ 语义副本被清理时,
+        用与首次下载 _build_file_path 完全相同的 code 规范化和 doc_type
+        label 派发推导目标路径, 从 hash 副本还原。各市场必须覆写并复刻
+        自己的派发逻辑 (直接抄通用规则会错 code 补零/label 映射)。
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} 未实现 build_semantic_cache_path"
+        )
+
     def _build_file_path(
         self,
         code: str,

--- a/unified_downloader/adapters/h_stock.py
+++ b/unified_downloader/adapters/h_stock.py
@@ -6,6 +6,7 @@ import logging
 import re
 from datetime import date, datetime, timedelta
 from typing import Optional, List, Dict, Any, Callable
+from pathlib import Path
 
 
 from unified_downloader.adapters.base import BaseStockAdapter
@@ -253,6 +254,27 @@ class HStockAdapter(BaseStockAdapter):
             return stock_info["id"]
 
         return None
+
+    # W40-#49: doc_type → 文件名 label, 与 download() 分发一致
+    _SEMANTIC_LABELS = {
+        "annual_report": "ANNUAL_REPORT", "年报": "ANNUAL_REPORT",
+        "interim_report": "INTERIM_REPORT", "中期报告": "INTERIM_REPORT",
+        "半年报": "INTERIM_REPORT",
+        "quarterly": "QUARTERLY_REPORT", "季度": "QUARTERLY_REPORT",
+        "prospectus": "PROSPECTUS", "招股说明书": "PROSPECTUS",
+        "招股书": "PROSPECTUS", "s1": "PROSPECTUS",
+    }
+
+    def build_semantic_cache_path(
+        self, code: str, year: Optional[int], document_type: str, ext: str
+    ) -> Path:
+        """W40-#49: 复刻港股下载命名 — upper + zfill(5), 扩展名用缓存
+        文件后缀 (.pdf/.html 由原始链接决定)"""
+        stock_code = code.upper().zfill(5)
+        label = self._SEMANTIC_LABELS.get(
+            str(document_type).lower(), "ANNUAL_REPORT"
+        )
+        return self._build_file_path(stock_code, year, label, ext)
 
     def _download_annual_report(
         self,

--- a/unified_downloader/core/async_downloader.py
+++ b/unified_downloader/core/async_downloader.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import time
+from pathlib import Path
 from typing import Optional, List, Dict, Any, Callable
 
 from unified_downloader.models.enums import Market, EventType
@@ -66,19 +67,31 @@ class AsyncUnifiedDownloader:
         if market is None:
             market = self._downloader._detect_market(code)
 
-        cached_path = self._downloader._cache_manager.get(
+        hit = self._downloader._cache_manager.get(
             market.value, code, year, document_type
         )
-        if cached_path:
-            restored_path = self._downloader._restore_semantic_cache_path(
-                market, code, year, document_type, cached_path
-            )
-            return DownloadResult(
-                success=True,
-                file_path=restored_path,
-                cached=True,
-                metadata={"cache_path": cached_path},
-            )
+        if hit:
+            # W40-#49: 与同步路径一致 — 语义路径直接返回; 老条目走还原。
+            # 另补齐 V4: 要 PDF 而缓存是 HTML 时不短路缓存 (sync 已有,
+            # async 之前缺失, 行为分叉)
+            restored_path = hit.path
+            if restored_path == hit.hash_path:
+                restored_path = self._downloader._restore_semantic_cache_path(
+                    market, code, year, document_type, hit.hash_path
+                )
+            wants_pdf = kwargs.get("convert_to_pdf") is True
+            if not (
+                market == Market.M
+                and wants_pdf
+                and Path(restored_path).suffix.lower() in (".html", ".htm")
+            ):
+                return DownloadResult(
+                    success=True,
+                    file_path=restored_path,
+                    cached=True,
+                    metadata={"cache_path": hit.hash_path},
+                )
+            # 显式要 PDF 但缓存是 HTML → 落到直接下载
 
         # 执行下载
         return await self._download_direct(

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -162,16 +162,20 @@ class UnifiedDownloader:
 
         # 检查缓存
         if use_cache and self.config.download.cache_enabled:
-            cached_path = self._cache_manager.get(
+            hit = self._cache_manager.get(
                 market.value, code, year, document_type
             )
-            if cached_path:
-                # US SEC downloads are cached under MD5 keys.  Returning those
-                # paths directly makes downstream IMA uploads show hash filenames.
-                # Restore a semantic downloads/... filename before reporting a hit.
-                restored_path = self._restore_semantic_cache_path(
-                    market, code, year, document_type, cached_path
-                )
+            if hit:
+                # W40-#49: 新条目缓存层已记住语义路径 → 直接返回, 零还原
+                # 零网络 (此前美股每次命中都调 edgar.Company() 发 SEC 请求
+                # 只为起文件名, A/H 更是直接返回 data/cache hash 乱码路径,
+                # 这就是 morning-brief DB file_path 不统一的根因)。
+                # 老条目 (无 semantic_path) 或语义副本被清理 → 还原兼容层。
+                restored_path = hit.path
+                if restored_path == hit.hash_path:
+                    restored_path = self._restore_semantic_cache_path(
+                        market, code, year, document_type, hit.hash_path
+                    )
 
                 # If the caller explicitly asks for PDF but the cached US artifact
                 # is HTML, do not short-circuit here.  Let the US adapter download
@@ -197,7 +201,7 @@ class UnifiedDownloader:
                         file_size=Path(restored_path).stat().st_size,
                         cached=True,
                         duration_ms=duration_ms,
-                        metadata={"cache_path": cached_path},
+                        metadata={"cache_path": hit.hash_path},
                     )
 
         # 生成任务ID
@@ -410,8 +414,29 @@ class UnifiedDownloader:
         makes uploaded documents unsearchable.
         """
         cached = Path(cached_path)
-        if market != Market.M or not cached.exists():
+        if not cached.exists():
             return cached_path
+
+        if market != Market.M:
+            # W40-#49: A/H 老条目之前直接返回 data/cache/... hash 路径
+            # (DB 路径不统一的直接根因之一)。现在用 adapter 复刻下载命名
+            # 规则本地推导, 无网络请求; EU 等未实现的市场维持原样。
+            adapter = self._adapters.get(market)
+            if adapter is None:
+                return cached_path
+            try:
+                target = adapter.build_semantic_cache_path(
+                    code, year, document_type, cached.suffix
+                )
+            except NotImplementedError:
+                return cached_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if cached.resolve() != target.resolve() and (
+                not target.exists() or target.stat().st_size != cached.stat().st_size
+            ):
+                shutil.copy2(str(cached), str(target))
+            self._backfill_semantic_path(market, code, year, document_type, target)
+            return str(target)
 
         ticker = code.upper()
         doc_label = self._semantic_us_doc_label(document_type)
@@ -443,7 +468,24 @@ class UnifiedDownloader:
             not target.exists() or target.stat().st_size != cached.stat().st_size
         ):
             shutil.copy2(str(cached), str(target))
+        self._backfill_semantic_path(market, code, year, document_type, target)
         return str(target)
+
+    def _backfill_semantic_path(
+        self,
+        market: Market,
+        code: str,
+        year: Optional[int],
+        document_type: str,
+        target: Path,
+    ) -> None:
+        """W40-#49: 还原成功后懒回填 — 下次命中直接走语义路径, 免还原"""
+        try:
+            self._cache_manager.set_semantic_path(
+                market.value, code, year, document_type, str(target)
+            )
+        except Exception as exc:
+            logger.debug("semantic path backfill failed: %s", exc)
 
     @staticmethod
     def _semantic_us_doc_label(document_type: str) -> str:

--- a/unified_downloader/infra/cache.py
+++ b/unified_downloader/infra/cache.py
@@ -24,6 +24,27 @@ class CacheEntry:
     md5: Optional[str] = None
 
 
+@dataclass
+class CacheHit:
+    """缓存命中结果 (W40-#49).
+
+    hash_path: 缓存持久层路径 data/cache/<market>/<prefix>/<md5>.<ext>
+    semantic_path: 首次下载时的语义路径 (downloads/...), 老条目为 None;
+        语义副本 (downloads/ 下可见文件) 被清理时也置 None, 由调用方从
+        hash 副本还原 — 删条目只看 hash 副本是否健在。
+    """
+
+    hash_path: str
+    semantic_path: Optional[str] = None
+
+    @property
+    def path(self) -> str:
+        """优先语义路径; 语义副本缺失时回 hash 路径 (调用方需还原)"""
+        if self.semantic_path and Path(self.semantic_path).exists():
+            return self.semantic_path
+        return self.hash_path
+
+
 class CacheManager:
     """
     本地缓存管理器
@@ -52,6 +73,7 @@ class CacheManager:
                 CREATE TABLE IF NOT EXISTS cache_entries (
                     key TEXT PRIMARY KEY,
                     file_path TEXT NOT NULL,
+                    semantic_path TEXT,
                     size INTEGER NOT NULL,
                     created_at TEXT NOT NULL,
                     expires_at TEXT NOT NULL,
@@ -60,6 +82,18 @@ class CacheManager:
                     last_access TEXT
                 )
             """)
+            # W40-#49: 老库迁移 — 缺列才 ALTER (并发进程同时升级会撞
+            # duplicate column, 包 OperationalError)
+            cols = {
+                row[1] for row in conn.execute("PRAGMA table_info(cache_entries)")
+            }
+            if "semantic_path" not in cols:
+                try:
+                    conn.execute(
+                        "ALTER TABLE cache_entries ADD COLUMN semantic_path TEXT"
+                    )
+                except sqlite3.OperationalError:
+                    pass
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_expires_at ON cache_entries(expires_at)
             """)
@@ -88,14 +122,14 @@ class CacheManager:
             doc_type: 文档类型
 
         Returns:
-            缓存文件路径，如果不存在或已过期返回None
+            CacheHit (hash_path + semantic_path)，不存在/过期返回 None
         """
         key = self._make_key(market, code, year, doc_type)
 
         with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             row = conn.execute(
                 """
-                SELECT file_path, expires_at FROM cache_entries
+                SELECT file_path, semantic_path, expires_at FROM cache_entries
                 WHERE key = ?
             """,
                 (key,),
@@ -104,12 +138,12 @@ class CacheManager:
             if not row:
                 return None
 
-            file_path = row[0]
-            expires_at = datetime.fromisoformat(row[1])
+            hash_path, semantic_path, expires_at = row[0], row[1], row[2]
+            expires_at = datetime.fromisoformat(expires_at)
 
             # 检查是否过期
             if datetime.now() > expires_at:
-                self._delete_entry(key, file_path)
+                self._delete_entry(key, hash_path)
                 return None
 
             # 更新访问记录
@@ -122,13 +156,16 @@ class CacheManager:
                 (datetime.now().isoformat(), key),
             )
 
-            # 返回文件路径
-            if Path(file_path).exists():
-                return file_path
+            # W40-#49: 删条目只看 hash 副本 (缓存的持久层); downloads/
+            # 语义副本被人工清理不算缓存失效, 走还原重建即可
+            if not Path(hash_path).exists():
+                self._delete_entry(key, hash_path)
+                return None
 
-            # 文件不存在，删除记录
-            self._delete_entry(key, file_path)
-            return None
+            if semantic_path and not Path(semantic_path).exists():
+                semantic_path = None  # 语义副本丢了 → 调用方还原
+
+            return CacheHit(hash_path=hash_path, semantic_path=semantic_path)
 
     def put(
         self,
@@ -173,12 +210,33 @@ class CacheManager:
         if str(file_path) != str(cached_path):
             shutil.copy2(str(file_path), str(cached_path))
 
+        # W40-#49: 记住语义路径, 命中时直接返回 (消灭"还原"常态)。
+        # 入参本身是缓存路径时 (resolve 前缀归属判断, 而非字符串相等)
+        # 存 NULL 且保留旧值 — 不把 hash 路径误存成语义路径
+        try:
+            is_inside_cache = Path(file_path).resolve().is_relative_to(
+                self._cache_dir.resolve()
+            )
+        except (OSError, ValueError):
+            is_inside_cache = False
+        semantic_to_store = None if is_inside_cache else str(file_path)
+
         with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
             conn.execute(
                 """
-                INSERT OR REPLACE INTO cache_entries
-                (key, file_path, size, created_at, expires_at, md5, last_access)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO cache_entries
+                (key, file_path, size, created_at, expires_at, md5,
+                 last_access, semantic_path)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    file_path=excluded.file_path,
+                    size=excluded.size,
+                    created_at=excluded.created_at,
+                    expires_at=excluded.expires_at,
+                    md5=excluded.md5,
+                    last_access=excluded.last_access,
+                    semantic_path=COALESCE(excluded.semantic_path,
+                                           cache_entries.semantic_path)
             """,
                 (
                     key,
@@ -188,6 +246,7 @@ class CacheManager:
                     expires_at.isoformat(),
                     md5,
                     now.isoformat(),
+                    semantic_to_store,
                 ),
             )
 
@@ -195,6 +254,22 @@ class CacheManager:
         self._maybe_cleanup()
 
         return key
+
+    def set_semantic_path(
+        self,
+        market: str,
+        code: str,
+        year: Optional[int],
+        doc_type: str,
+        semantic_path: str,
+    ) -> None:
+        """W40-#49: 懒回填语义路径 — 还原成功后调用, 下次命中免还原"""
+        key = self._make_key(market, code, year, doc_type)
+        with closing(sqlite3.connect(str(self._db_path))) as conn, conn:
+            conn.execute(
+                "UPDATE cache_entries SET semantic_path = ? WHERE key = ?",
+                (semantic_path, key),
+            )
 
     def _delete_entry(self, key: str, file_path: str) -> None:
         """删除缓存条目"""


### PR DESCRIPTION
## 背景

#49：morning-brief DB `file_path` 记录不统一（`downloads/m/NVD/NVDA_2026_10Q.pdf` vs `data/cache/m/PDD/0e34a11...` 乱码）。

**方案先经对抗验证**（Plan agent 审查推翻了初版设计的两处：get() 单一返回值装不下 metadata 契约、"语义副本缺失删条目"会误删健康缓存），并修正了 #49 原始认知：`base._build_file_path` 已是全部市场统一入口，原任务 B1/B2 不需要做；真正病灶在**缓存层**——只存 hash 路径 + "语义还原"只覆盖美股（A/H 命中直接返回乱码路径）且美股还原每次发 SEC 网络请求只为起文件名。

## 改动

| 层 | 内容 |
|---|---|
| `cache.py` | `cache_entries` 加 `semantic_path` 列（新库建列 + 老库 `PRAGMA` 探测 ALTER 迁移）；`get()` 返回 `CacheHit`（hash_path + semantic_path + path property）；`put()` 存语义路径（入参是缓存路径时存 NULL + `ON CONFLICT COALESCE` 保旧值）；**删条目只看 hash 副本**（downloads/ 语义副本被清理不算失效，走还原重建）；`set_semantic_path` 懒回填 |
| adapters | `build_semantic_cache_path()`：复刻各自下载命名规则（A股：去 SH/SZ 前缀 + zfill(6) + label 派发映射 + 固定 .PDF；港股：zfill(5) + 缓存后缀）；base 默认 NotImplementedError；美股不实现（走既有还原） |
| downloader/async | 命中语义路径**直接返回，零还原零网络**（此前美股每次命中调 `edgar.Company()` 打 SEC）；老条目/语义副本丢失 → 美股保留现有还原，**A/H 改本地推导**（修掉"直接返回乱码路径"）+ 懒回填；`metadata["cache_path"]` 恒为 hash 路径（契约不变）；顺手补齐 async 缺失的"要 PDF 但缓存是 HTML 不短路"判断 |
| README | 路径规范节（#49 任务 B5）：目录规范、缓存双层结构（hash 持久层 + downloads/ 语义视图）、相对路径说明；B4 历史 DB 记录不迁移（留 morning-brief/服务器侧） |

## 效果（对 #49 的原始诉求）

- 同一文档无论第几次下载，DB 记录的路径一致（语义路径）
- 缓存命中不再有 SEC 网络请求（此前美股每次命中一发）
- A/H 市场缓存命中不再返回 `data/cache/{md5}` 乱码路径

## 测试

新增 `test_cache_semantic_path.py` **12 用例**：老库 schema 迁移、put 防御（缓存路径入参不写坏 semantic）、A/H 推导矩阵（`600519`/`sh600519`、`700`/`00700`、q1→QUARTERLY_REPORT、未知→ANNUAL_REPORT、year=None）、**美股二次命中零网络**（mock `get_annual_form_type` 为 raise）、**A 股老条目还原为语义路径非 hash**、懒回填幂等。全量 **248 passed**（含 7 个既有语义文件名契约测试原样通过）；真实缓存库副本迁移 spot check 通过。

Closes #49
Refs #50（路径统一项勾选）