### PR TITLE
fix(#50): 快修批 — h_stock 多檔案防护 / translator key 走 env / 三脚本统一 / 装饰性测试重写

### DIFF
--- a/scripts/bulk_common.py
+++ b/scripts/bulk_common.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""bulk 链路共享工具 (W40-#50: 三脚本副本语义统一).
+
+之前 run/compute_summary/upload_ima/_resolve_ima_script 在
+bulk_download.py / bulk_scheduler.py / fix_us_html_ima.py 各有一份且
+语义漂移 (bulk 把 downloaded 一律算 ok, scheduler 要求 ima 非失败才算
+ok; fix 的 ✅ 判定宽松到"成功 0"也通过)。统一采用最严格的语义。
+
+所有函数显式传参 (project_root/logger), 不读本模块级常量 — 调用方
+(及其测试的 monkeypatch) 传入什么就用什么。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+# 旧 openclaw 服务器路径, 仅作查找链 fallback (标准位置是仓库内
+# scripts/sync_to_ima.sh, 见 resolve_ima_script)
+LEGACY_IMA_SYNC_SCRIPT = (
+    Path.home() / ".openclaw" / "workspace" / "skills"
+    / "unified-downloader" / "scripts" / "sync_to_ima.sh"
+)
+
+
+def run(cmd, timeout: int = 120, project_root: Path | None = None):
+    """跑子命令, TimeoutExpired 转 rc=124 不穿透 (超时隔离版语义)."""
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+            cwd=str(project_root) if project_root else None,
+        )
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except subprocess.TimeoutExpired as e:
+        def _s(v):
+            return v.decode("utf-8", "replace").strip() if isinstance(v, bytes) else (v or "").strip()
+        err = _s(e.stderr) or f"timeout after {timeout}s"
+        if f"timeout after {timeout}s" not in err:
+            err = f"{err} (timeout after {timeout}s)"
+        return 124, _s(e.stdout), err
+
+
+def resolve_ima_script(project_root: Path) -> Path:
+    """IMA 同步脚本查找链: 环境变量 → 仓库内 scripts/sync_to_ima.sh →
+    旧 ~/.openclaw 路径。"""
+    env = os.environ.get("IMA_SYNC_SCRIPT_PATH")
+    if env:
+        return Path(env)
+    in_repo = Path(project_root) / "scripts" / "sync_to_ima.sh"
+    if in_repo.exists():
+        return in_repo
+    return LEGACY_IMA_SYNC_SCRIPT
+
+
+def _is_ima_success(value: str | None) -> bool:
+    return value == "uploaded"
+
+
+def _is_ima_failure(value: str | None) -> bool:
+    return bool(value and value != "uploaded")
+
+
+def compute_summary(state: dict) -> dict:
+    """从 per-document 状态计算汇总 (scheduler 严格版语义).
+
+    per-document 记录是 source of truth; IMA 失败可能是非常规 reason
+    字符串 (如 semantic_upload_rate_limited), 不能只认 "failed"。
+    """
+    sm = {
+        "annual_ok": 0, "annual_skipped": 0, "annual_failed": 0,
+        "quarterly_ok": 0, "quarterly_skipped": 0, "quarterly_failed": 0,
+        "ima_ok": 0, "ima_failed": 0,
+    }
+    for d in state.get("annual", {}).values():
+        status = d.get("status", "")
+        if status == "uploaded" or (
+            status == "downloaded" and not _is_ima_failure(d.get("ima"))
+        ):
+            sm["annual_ok"] += 1
+        elif status == "skipped":
+            sm["annual_skipped"] += 1
+        elif "failed" in status:
+            sm["annual_failed"] += 1
+        if _is_ima_success(d.get("ima")):
+            sm["ima_ok"] += 1
+        elif _is_ima_failure(d.get("ima")) or status == "ima_failed":
+            sm["ima_failed"] += 1
+    for qs in state.get("quarterly", {}).values():
+        for d in qs.values():
+            status = d.get("status", "")
+            if status == "uploaded" or (
+                status == "downloaded" and not _is_ima_failure(d.get("ima"))
+            ):
+                sm["quarterly_ok"] += 1
+            elif status == "skipped":
+                sm["quarterly_skipped"] += 1
+            elif "failed" in status:
+                sm["quarterly_failed"] += 1
+            if _is_ima_success(d.get("ima")):
+                sm["ima_ok"] += 1
+            elif _is_ima_failure(d.get("ima")) or status == "ima_failed":
+                sm["ima_failed"] += 1
+    return sm
+
+
+def upload_ima(fpath, kb: str = "年报季度报知识库",
+               project_root: Path | None = None, logger=None) -> bool:
+    """上传单文件到 IMA (完整判定版: 严格成功标记 + 显式失败/跳过标记)。
+
+    sync_to_ima.sh 可能 exit 0 但 create_media 失败, 依赖 per-file
+    成功/重复标记判定; "✅ 成功 [1-9]" 严格匹配 (宽松的 "✅ 出现" 会把
+    "成功 0" 判成功)。
+    """
+    if logger is None:
+        import logging
+        logger = logging.getLogger("bulk")
+    ima_script = resolve_ima_script(project_root)
+    if not ima_script.exists():
+        logger.error(
+            "    IMA sync script missing: %s (set IMA_SYNC_SCRIPT_PATH or put "
+            "scripts/sync_to_ima.sh in repo)", ima_script,
+        )
+        return False
+    rc, out, err = run(
+        ["bash", str(ima_script), "--file", str(fpath),
+         "--kb-name", kb, "--force"],
+        timeout=300, project_root=project_root,
+    )
+    combined = out + "\n" + err
+    lower = combined.lower()
+
+    success_mark = (
+        "Upload successful" in combined
+        or "已添加到知识库" in combined
+        or re.search(r"✅\s*成功\s*[1-9]", combined) is not None
+    )
+    duplicate_ok = "already exists" in lower or "已存在" in combined
+    failure_mark = (
+        "create_media 失败" in combined
+        or "请求超量" in combined
+        or re.search(r"失败\s*[1-9]", combined) is not None
+    )
+    skipped_mark = (
+        "unsupported" in lower
+        or "不支持" in combined
+        or "Web pages must be added via URL" in combined
+        or "跳过 1" in combined
+        or "skipped 1" in lower
+    )
+    ok = (rc == 0 and (success_mark or duplicate_ok)
+          and not skipped_mark and not failure_mark)
+    if ok:
+        logger.info("    IMA: ✓ %s", Path(fpath).name)
+    else:
+        logger.error(
+            "    IMA: ✗ %s rc=%s stdout=%s stderr=%s",
+            Path(fpath).name, rc, out[-500:], err[-500:],
+        )
+    return ok

--- a/scripts/bulk_download.py
+++ b/scripts/bulk_download.py
@@ -58,15 +58,8 @@ TZ_CN = timezone(timedelta(hours=8))
 
 
 def _resolve_ima_script() -> Path:
-    """IMA 同步脚本查找链: 环境变量 → 仓库内 scripts/sync_to_ima.sh →
-    旧 ~/.openclaw 路径。调用时解析 (非模块加载时), 进程内改 env 也生效。"""
-    env = os.environ.get("IMA_SYNC_SCRIPT_PATH")
-    if env:
-        return Path(env)
-    in_repo = PROJECT_ROOT / "scripts" / "sync_to_ima.sh"
-    if in_repo.exists():
-        return in_repo
-    return LEGACY_IMA_SYNC_SCRIPT
+    """IMA 同步脚本查找链 (委托 bulk_common, PROJECT_ROOT 调用时读取)。"""
+    return bulk_common.resolve_ima_script(PROJECT_ROOT)
 
 ANNUAL_MAP = {"CN": "annual_report", "HK": "annual_report", "US": "10k", "US_20F": "20f"}
 QUARTERLY_MAP = {
@@ -129,6 +122,10 @@ from unified_downloader.utils.adr_map import (
     resolve_target,
     is_adr_skipped,
 )
+
+# W40-#50: 三脚本共享工具 (run/compute_summary/upload_ima 统一严格语义)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bulk_common  # noqa: E402
 
 def quarterly_search_market(is_adr_hk, is_20f, mkt_key):
     if is_adr_hk:
@@ -205,43 +202,8 @@ def validate_file(fpath):
     return True
 
 def upload_ima(fpath, kb="年报季度报知识库"):
-    ima_script = _resolve_ima_script()
-    if not ima_script.exists():
-        log.error("    IMA sync script missing: %s (set IMA_SYNC_SCRIPT_PATH or put "
-                  "scripts/sync_to_ima.sh in repo)", ima_script)
-        return False
-    rc, out, err = run(["bash", str(ima_script), "--file", str(fpath),
-                        "--kb-name", kb, "--force"], timeout=300)
-    combined = out + "\n" + err
-    lower = combined.lower()
-
-    # sync_to_ima.sh may exit 0 even when create_media fails; rely on
-    # per-file success/duplicate markers and reject explicit failure summary.
-    success_mark = (
-        "Upload successful" in combined
-        or "已添加到知识库" in combined
-        or re.search(r"✅\s*成功\s*[1-9]", combined) is not None
-    )
-    duplicate_ok = "already exists" in lower or "已存在" in combined
-    failure_mark = (
-        "create_media 失败" in combined
-        or "请求超量" in combined
-        or re.search(r"失败\s*[1-9]", combined) is not None
-    )
-    skipped_mark = (
-        "unsupported" in lower
-        or "不支持" in combined
-        or "Web pages must be added via URL" in combined
-        or "跳过 1" in combined
-        or "skipped 1" in lower
-    )
-    ok = (rc == 0 and (success_mark or duplicate_ok) and not skipped_mark and not failure_mark)
-    if ok:
-        log.info("    IMA: ✓ %s", fpath.name)
-    else:
-        log.error("    IMA: ✗ %s rc=%s stdout=%s stderr=%s",
-                  fpath.name, rc, out[-500:], err[-500:])
-    return ok
+    """委托 bulk_common (完整判定版语义不变)。"""
+    return bulk_common.upload_ima(fpath, kb=kb, project_root=PROJECT_ROOT, logger=log)
 
 def log_failure(code, name, detail):
     p = LOG_DIR / "failures.log"
@@ -346,36 +308,10 @@ def should_mark_quarterly_unavailable(state, year, qlabel, form_type=None):
     return True
 
 def compute_summary(state: dict) -> dict:
-    """从细粒度状态计算汇总"""
-    s = {"annual_ok": 0, "annual_skipped": 0, "annual_failed": 0,
-         "quarterly_ok": 0, "quarterly_skipped": 0, "quarterly_failed": 0,
-         "ima_ok": 0, "ima_failed": 0}
-    for y, d in state.get("annual", {}).items():
-        st = d.get("status", "")
-        if st in ("downloaded", "uploaded"):
-            s["annual_ok"] += 1
-        elif st == "skipped":
-            s["annual_skipped"] += 1
-        elif "failed" in st:
-            s["annual_failed"] += 1
-        if d.get("ima") == "uploaded":
-            s["ima_ok"] += 1
-        elif d.get("ima") == "failed":
-            s["ima_failed"] += 1
-    for y, qs in state.get("quarterly", {}).items():
-        for q, d in qs.items():
-            st = d.get("status", "")
-            if st in ("downloaded", "uploaded"):
-                s["quarterly_ok"] += 1
-            elif st == "skipped":
-                s["quarterly_skipped"] += 1
-            elif "failed" in st:
-                s["quarterly_failed"] += 1
-            if d.get("ima") == "uploaded":
-                s["ima_ok"] += 1
-            elif d.get("ima") == "failed":
-                s["ima_failed"] += 1
-    return s
+    """委托 bulk_common — W40-#50: 统一为 scheduler 严格版语义
+    (downloaded 且 ima 非失败才算 ok; ima 字段的非常规失败值如
+    semantic_upload_rate_limited 也计入 ima_failed)。"""
+    return bulk_common.compute_summary(state)
 
 # ── 主流程 ──
 

--- a/scripts/bulk_scheduler.py
+++ b/scripts/bulk_scheduler.py
@@ -14,6 +14,10 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# W40-#50: compute_summary 统一到 bulk_common (原本地副本即严格版语义)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bulk_common import compute_summary as _common_compute_summary  # noqa: E402
 QUEUE_FILE = PROJECT_ROOT / "data" / "bulk_download_queue.json"
 STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
 LOG_FILE = PROJECT_ROOT / "logs" / "bulk_download.log"
@@ -199,44 +203,9 @@ def _is_ima_failure(value: str | None) -> bool:
 
 
 def compute_summary_from_state(st: dict) -> dict:
-    """Compute summary from per-document state.
-
-    The per-document records are the source of truth.  Older state files may have
-    stale/optimistic ``summary`` blocks, and IMA failures can be represented by
-    specific reason strings such as ``semantic_upload_rate_limited`` rather than
-    exactly ``failed``.
-    """
-    sm = {
-        "annual_ok": 0, "annual_skipped": 0, "annual_failed": 0,
-        "quarterly_ok": 0, "quarterly_skipped": 0, "quarterly_failed": 0,
-        "ima_ok": 0, "ima_failed": 0,
-    }
-    for d in st.get("annual", {}).values():
-        status = d.get("status", "")
-        if status == "uploaded" or (status == "downloaded" and not _is_ima_failure(d.get("ima"))):
-            sm["annual_ok"] += 1
-        elif status == "skipped":
-            sm["annual_skipped"] += 1
-        elif "failed" in status:
-            sm["annual_failed"] += 1
-        if _is_ima_success(d.get("ima")):
-            sm["ima_ok"] += 1
-        elif _is_ima_failure(d.get("ima")) or status == "ima_failed":
-            sm["ima_failed"] += 1
-    for qs in st.get("quarterly", {}).values():
-        for d in qs.values():
-            status = d.get("status", "")
-            if status == "uploaded" or (status == "downloaded" and not _is_ima_failure(d.get("ima"))):
-                sm["quarterly_ok"] += 1
-            elif status == "skipped":
-                sm["quarterly_skipped"] += 1
-            elif "failed" in status:
-                sm["quarterly_failed"] += 1
-            if _is_ima_success(d.get("ima")):
-                sm["ima_ok"] += 1
-            elif _is_ima_failure(d.get("ima")) or status == "ima_failed":
-                sm["ima_failed"] += 1
-    return sm
+    """Compute summary from per-document state (W40-#50: 委托 bulk_common,
+    语义不变 — 严格版本来就是从这里统一的)."""
+    return _common_compute_summary(st)
 
 
 def get_state_summary(st: dict) -> dict:

--- a/scripts/fix_us_html_ima.py
+++ b/scripts/fix_us_html_ima.py
@@ -23,12 +23,16 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# W40-#50: 共享工具 (超时隔离 run / 严格 compute_summary / 完整判定
+# upload_ima / IMA 查找链)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bulk_common  # noqa: E402
 STATE_DIR = PROJECT_ROOT / "data" / "bulk_state"
 QUEUE_FILE = PROJECT_ROOT / "data" / "bulk_download_queue.json"
 LOG_DIR = PROJECT_ROOT / "logs"
 FIX_LOG = LOG_DIR / "fix_us_html_ima.log"
-DEFAULT_IMA_SYNC_SCRIPT = Path.home() / ".openclaw" / "workspace" / "skills" / "unified-downloader" / "scripts" / "sync_to_ima.sh"
-IMA_SYNC_SCRIPT = Path(os.environ.get("IMA_SYNC_SCRIPT_PATH", DEFAULT_IMA_SYNC_SCRIPT))
+IMA_SYNC_SCRIPT = bulk_common.resolve_ima_script(PROJECT_ROOT)  # W40-#50: 查找链 (原仅 env→legacy)
 TZ_CN = timezone(timedelta(hours=8))
 
 LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -42,8 +46,8 @@ log = logging.getLogger("fix_us_html_ima")
 
 
 def run(cmd: list[str], timeout: int) -> tuple[int, str, str]:
-    r = subprocess.run(cmd, cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=timeout)
-    return r.returncode, r.stdout.strip(), r.stderr.strip()
+    """W40-#50: 委托 bulk_common — 超时不再穿透 (原版直接抛异常)。"""
+    return bulk_common.run(cmd, timeout=timeout, project_root=PROJECT_ROOT)
 
 
 def load_queue_names() -> dict[str, str]:
@@ -54,42 +58,8 @@ def load_queue_names() -> dict[str, str]:
 
 
 def compute_summary(state: dict) -> dict:
-    s = {
-        "annual_ok": 0,
-        "annual_skipped": 0,
-        "annual_failed": 0,
-        "quarterly_ok": 0,
-        "quarterly_skipped": 0,
-        "quarterly_failed": 0,
-        "ima_ok": 0,
-        "ima_failed": 0,
-    }
-    for d in state.get("annual", {}).values():
-        st = d.get("status", "")
-        if st in ("downloaded", "uploaded"):
-            s["annual_ok"] += 1
-        elif st == "skipped":
-            s["annual_skipped"] += 1
-        elif "failed" in st:
-            s["annual_failed"] += 1
-        if d.get("ima") == "uploaded":
-            s["ima_ok"] += 1
-        elif d.get("ima") == "failed":
-            s["ima_failed"] += 1
-    for qs in state.get("quarterly", {}).values():
-        for d in qs.values():
-            st = d.get("status", "")
-            if st in ("downloaded", "uploaded"):
-                s["quarterly_ok"] += 1
-            elif st == "skipped":
-                s["quarterly_skipped"] += 1
-            elif "failed" in st:
-                s["quarterly_failed"] += 1
-            if d.get("ima") == "uploaded":
-                s["ima_ok"] += 1
-            elif d.get("ima") == "failed":
-                s["ima_failed"] += 1
-    return s
+    """W40-#50: 委托 bulk_common 严格版 (downloaded 且 ima 非失败才算 ok)。"""
+    return bulk_common.compute_summary(state)
 
 
 def should_fix(state: dict, year: str, entry: dict) -> bool:
@@ -142,14 +112,9 @@ def download_pdf(code: str, year: str, form_type: str) -> Path | None:
 
 
 def upload_ima(pdf: Path, kb: str = "年报季度报知识库") -> bool:
-    rc, out, err = run(["bash", str(IMA_SYNC_SCRIPT), "--file", str(pdf), "--kb-name", kb, "--force"], timeout=360)
-    combined = out + "\n" + err
-    success_mark = ("✅" in combined or "已添加到知识库" in combined or "Upload successful" in combined)
-    skipped = ("跳过 " in combined or "skipped " in combined.lower()) and not success_mark
-    ok = rc == 0 and not skipped and success_mark
-    if not ok:
-        log.error("IMA upload failed file=%s rc=%s stdout=%s stderr=%s", pdf.name, rc, out[-800:], err[-800:])
-    return ok
+    """W40-#50: 委托 bulk_common 完整判定版 — 原宽松版 "✅ 出现" 会把
+    "✅ 成功 0" 判成功, 且漏检 create_media 失败/请求超量标记。"""
+    return bulk_common.upload_ima(pdf, kb=kb, project_root=PROJECT_ROOT, logger=log)
 
 
 def main() -> int:

--- a/tests/test_batch_b_polish.py
+++ b/tests/test_batch_b_polish.py
@@ -1,0 +1,181 @@
+"""
+Regression tests for 批次 B 快修 (W40-#50).
+
+B1: h_stock 年报/中报多檔案防护 (之前只有招股书路径检查)
+B2: translator API key 经 wrapper 环境变量传递 (不进子进程 argv)
+B3: bulk_common 统一语义 (compute_summary 严格版 / upload_ima 完整判定)
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _load_script(name: str):
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace(".py", "_bt"), path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    if hasattr(module, "log"):
+        module.log = logging.getLogger(f"test-{name}")
+    return module
+
+
+# ═══ B1: h_stock 多檔案防护 ═══
+
+
+class TestHStockMultiFileGuard:
+    def _adapter(self):
+        from unified_downloader.adapters.h_stock import HStockAdapter
+
+        return HStockAdapter(MagicMock(), [])
+
+    def test_annual_report_multi_file_rejected(self):
+        """年报/中报路径的多檔案条目返回 MULTI_FILE 而非下载索引页"""
+        adapter = self._adapter()
+
+        class _FakeApi:
+            def search_documents(self, **kwargs):
+                return [{
+                    "file_link": "https://www1.hkexnews.hk/listedco/...",
+                    "file_info": "多檔案",
+                    "date_time": "31/12/2025 16:00",
+                }]
+
+        with patch.object(adapter, "_get_stock_id", return_value="123"), \
+             patch.object(adapter, "_get_api", return_value=_FakeApi()), \
+             patch.object(adapter, "_rate_limiter"):
+            result = adapter._download_report(
+                "00700", 2025, "annual_report", "ANNUAL_RESULTS", None, None
+            )
+
+        assert result.success is False
+        assert result.error_code == "MULTI_FILE"
+        assert "多檔案" in result.error_message
+
+    def test_normal_report_still_downloads(self):
+        """非多檔案条目不受新防护影响"""
+        adapter = self._adapter()
+
+        class _FakeApi:
+            def search_documents(self, **kwargs):
+                return [{
+                    "file_link": "https://www1.hkexnews.hk/x.pdf",
+                    "file_info": "",
+                    "date_time": "31/12/2025 16:00",
+                }]
+
+        fake_dl = MagicMock(return_value={"file_path": "/tmp/x.pdf", "file_size": 123})
+
+        with patch.object(adapter, "_get_stock_id", return_value="123"), \
+             patch.object(adapter, "_get_api", return_value=_FakeApi()), \
+             patch.object(adapter, "_rate_limiter"), \
+             patch.object(adapter._http_client, "download_file", fake_dl):
+            result = adapter._download_report(
+                "00700", 2025, "annual_report", "ANNUAL_RESULTS", None, None
+            )
+
+        assert result.success is True
+        fake_dl.assert_called_once()
+
+
+# ═══ B2: translator key 走 wrapper env ═══
+
+
+class TestTranslatorKeyViaEnv:
+    def test_wrapper_path_key_not_in_argv(self, tmp_path, monkeypatch):
+        """wrapper 存在时: key 不进 cmd argv, 经 env 传子进程"""
+        from unified_downloader.infra import translator
+
+        pdf = tmp_path / "t.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n" + b"x" * 128)
+        captured = {}
+
+        class _FakeProc:
+            returncode = 1
+            stdout = ""
+            stderr = "fake failure (output discovery not under test)"
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            return _FakeProc()
+
+        monkeypatch.setattr(translator.subprocess, "run", fake_run)
+        monkeypatch.setattr(translator.time, "sleep", lambda s: None)
+
+        from unified_downloader.exceptions import TranslationError
+        with pytest.raises(TranslationError):
+            translator.PDFTranslator.translate(
+                pdf, api_key="sk-SECRET", use_cache=False
+            )
+
+        assert "--openai-api-key" not in captured["cmd"], "key 不得进 argv (ps 可见)"
+        assert "sk-SECRET" not in " ".join(captured["cmd"])
+        assert captured["env"]["UNIFIED_DOWNLOADER_TRANSLATE_KEY"] == "sk-SECRET"
+
+
+# ═══ B3: bulk_common 统一语义 ═══
+
+
+class TestBulkCommonSemantics:
+    def _common(self):
+        spec = importlib.util.spec_from_file_location(
+            "bulk_common_bt", ROOT / "scripts" / "bulk_common.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_compute_summary_strict_ima_semantics(self):
+        bc = self._common()
+        state = {
+            "annual": {
+                "2025": {"status": "downloaded", "ima": "semantic_upload_rate_limited"},
+                "2024": {"status": "downloaded", "ima": None},
+                "2023": {"status": "skipped"},
+            }
+        }
+        sm = bc.compute_summary(state)
+        # downloaded 但 ima 非常规失败值 → 不算 ok, 计入 ima_failed
+        assert sm["annual_ok"] == 1
+        assert sm["annual_skipped"] == 1
+        assert sm["ima_failed"] == 1
+
+    def test_upload_ima_rejects_zero_success_marker(self, tmp_path):
+        """宽松的 '✅ 出现' 会把 '成功 0' 判成功 — 完整判定版必须拒绝"""
+        bc = self._common()
+        f = tmp_path / "x.pdf"
+        f.write_bytes(b"%PDF x")
+        captured = {}
+
+        def fake_run(cmd, timeout=120, project_root=None):
+            captured["cmd"] = cmd
+            return 0, "✅ 成功 0", ""
+
+        with patch.object(bc, "run", side_effect=fake_run), \
+             patch.object(bc, "resolve_ima_script", return_value=f):
+            assert bc.upload_ima(f, project_root=tmp_path) is False
+
+        # 真正的成功标记 → 通过
+        def fake_run2(cmd, timeout=120, project_root=None):
+            return 0, "✅ 成功 1", ""
+
+        with patch.object(bc, "run", side_effect=fake_run2), \
+             patch.object(bc, "resolve_ima_script", return_value=f):
+            assert bc.upload_ima(f, project_root=tmp_path) is True
+
+    def test_three_scripts_share_common_module(self):
+        """三脚本的 compute_summary 均委托 bulk_common (单一事实源)"""
+        for name in ("bulk_download.py", "bulk_scheduler.py", "fix_us_html_ima.py"):
+            text = (ROOT / "scripts" / name).read_text()
+            assert "bulk_common" in text, f"{name} 未接入 bulk_common"

--- a/tests/test_m_stock_6k_size_fallback.py
+++ b/tests/test_m_stock_6k_size_fallback.py
@@ -12,7 +12,7 @@ Regression: 2026-08-13 NVO — 诺和诺德 6-K 是"单文档结构"（正文=pr
 """
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -59,28 +59,56 @@ class TestSixKSizeLargestFallback:
         assert picked is None  # 无 exhibit 可打分
 
     def test_fallback_selects_largest_size(self, adapter):
-        """
-        回退应选 size 最大的 filing（完整财报 2.78MB），
-        而非 filings[0]（回购公告 167KB）。
+        """W40-#50 重写: 真实走 _download_form 的 size 回退路径 (旧用例在
+        测试里直接调内置 max() 自证, adapter 一行代码都没执行)。
+
+        回退应把 size 最大的 filing (完整财报 2.78MB) 传给
+        _download_filing, 而非 filings[0] (回购公告 167KB)。
         """
         filings = [
             _mk_filing("0001171843-26-005376", 167508, "2026-08-10"),  # 回购公告
             _mk_filing("0000353278-26-000023", 2784789, "2026-08-04"),  # 完整财报
             _mk_filing("0001171843-26-005184", 167154, "2026-08-04"),  # 摘要
         ]
-        best = max(filings, key=lambda f: int(f.get("size") or 0))
-        assert best["accessionNo"] == "0000353278-26-000023"
-        assert best["size"] == 2784789
+        captured = {}
+        ok_result = MagicMock()
+        ok_result.success = True
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            # _download_filing 以 6 个位置参数调用 (filing, ticker, form,
+            # year, on_progress, checkpoint) — 侧签名要吃下其余位置参数
+            mock_dl.side_effect = (
+                lambda filing, *args, **kw:
+                    captured.update(filing=filing) or ok_result
+            )
+            adapter._download_form("NVO", "6-K", 2026, None, None)
+
+        assert captured["filing"]["accessionNo"] == "0000353278-26-000023"
+        assert captured["filing"]["size"] == 2784789
 
     def test_size_zero_falls_back_to_first(self, adapter):
-        """所有 size=0 时，回退仍取 filings[0]（不 crash）"""
+        """所有 size=0 时回退保持 filings[0]（不 crash）— 真实路径验证"""
         filings = [
             _mk_filing("A", 0),
             _mk_filing("B", 0),
             _mk_filing("C", 0),
         ]
-        best = max(filings, key=lambda f: int(f.get("size") or 0))
-        assert best["accessionNo"] == "A"
+        captured = {}
+        ok_result = MagicMock()
+        ok_result.success = True
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            # _download_filing 以 6 个位置参数调用 (filing, ticker, form,
+            # year, on_progress, checkpoint) — 侧签名要吃下其余位置参数
+            mock_dl.side_effect = (
+                lambda filing, *args, **kw:
+                    captured.update(filing=filing) or ok_result
+            )
+            adapter._download_form("NVO", "6-K", 2026, None, None)
+
+        assert captured["filing"]["accessionNo"] == "A"
 
     def test_large_exhibit_still_preferred(self, adapter):
         """有财报 exhibit 的仍优先于 size 回退（关键词打分优先）"""

--- a/tests/test_m_stock_meta_nonetype.py
+++ b/tests/test_m_stock_meta_nonetype.py
@@ -78,27 +78,45 @@ def test_download_succeeds_without_user_env():
     assert "unsupported operand" not in combined
 
 
-def test_default_user_agent_uses_unknown_when_user_unset():
-    """Direct unit check on the patched expression.
+def test_default_user_agent_uses_unknown_when_user_unset(monkeypatch):
+    """W40-#50 重写: 真实调用 _resolve_sec_user_agent (旧用例把被测
+    表达式复制进断言自证, m_stock 真回归它照样绿)。"""
+    sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+    from adapters.m_stock import _resolve_sec_user_agent
 
-    Mirrors the line in m_stock.py:
+    class _NoUaCfg:
+        sec_user_agent = None
 
-        user = os.environ.get("USER") or "Unknown"
-        sec_ua = f"{user}/contact@example.com Research Tool/1.0"
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("SEC_USER_AGENT", raising=False)
 
-    If a future refactor changes the default user string, this test
-    will fail and force an explicit decision.
-    """
-    env = {k: v for k, v in os.environ.items() if k != "USER"}
-    user = env.get("USER") or "Unknown"
-    assert user == "Unknown", "Expected 'Unknown' fallback when USER unset"
-    # Sanity: the expression must not raise.
-    ua = f"{user}/contact@example.com Research Tool/1.0"
+    ua = _resolve_sec_user_agent(_NoUaCfg())
+
     assert ua == "Unknown/contact@example.com Research Tool/1.0"
 
 
-def test_user_env_present_yields_actual_user():
-    """When USER IS set, the fallback should not mask it."""
-    env = {**os.environ, "USER": "winters"}
-    user = env.get("USER") or "Unknown"
-    assert user == "winters", "USER env should win over 'Unknown' fallback"
+def test_resolve_sec_user_agent_priority(monkeypatch):
+    """三档优先级: config 显式 > SEC_USER_AGENT env > USER 兜底"""
+    sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+    from adapters.m_stock import _resolve_sec_user_agent
+
+    class _CfgUa:
+        sec_user_agent = "Custom Agent/1.0"
+
+    class _NoUaCfg:
+        sec_user_agent = None
+
+    # 1. config 显式配置最高优先
+    assert _resolve_sec_user_agent(_CfgUa()) == "Custom Agent/1.0"
+
+    # 2. SEC_USER_AGENT env 次之
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.setenv("SEC_USER_AGENT", "EnvAgent/2.0")
+    assert _resolve_sec_user_agent(_NoUaCfg()) == "EnvAgent/2.0"
+
+    # 3. USER 兜底构造
+    monkeypatch.delenv("SEC_USER_AGENT", raising=False)
+    monkeypatch.setenv("USER", "winters")
+    assert _resolve_sec_user_agent(_NoUaCfg()) == (
+        "winters/contact@example.com Research Tool/1.0"
+    )

--- a/unified_downloader/adapters/h_stock.py
+++ b/unified_downloader/adapters/h_stock.py
@@ -553,6 +553,19 @@ class HStockAdapter(BaseStockAdapter):
         # 获取第一个文档
         doc = documents[0]
         file_link = doc.get("file_link", "")
+        file_info = doc.get("file_info", "")
+        # W40-#50: 多檔案防护 — 之前只有招股书路径检查, 年报/中报路径会把
+        # 多檔案条目的索引页当正文下载
+        if "多檔案" in file_info:
+            return DownloadResult(
+                success=False,
+                error_code="MULTI_FILE",
+                error_message=(
+                    f"{stock_code} {year or '最新'} 报告为多檔案类型，无法直接下载 PDF。"
+                    "请访问港交所披露易网页查看: "
+                    "https://www1.hkexnews.hk/search/titlesearch.xhtml"
+                ),
+            )
         if not file_link:
             return DownloadResult(
                 success=False,

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -58,6 +58,20 @@ def _report_period_target_end(report_period):
         return None
 
 
+def _resolve_sec_user_agent(cfg) -> str:
+    """构造 SEC 请求 User-Agent (W40-#50: 从 _download_filing 内联抽出可测).
+
+    W36 背景: 以前用 `os.environ.get("USER") + "..."`, cron wrapper/systemd
+    会 strip USER env → None + str → TypeError (META 26Q2 7-29 实际故障)。
+    优先级: config 显式配置 > SEC_USER_AGENT env > USER 兜底 "Unknown"。
+    """
+    user = os.environ.get("USER") or "Unknown"
+    cfg_ua = getattr(cfg, "sec_user_agent", None)
+    return cfg_ua or os.environ.get(
+        "SEC_USER_AGENT", f"{user}/contact@example.com Research Tool/1.0"
+    )
+
+
 def _primary_doc_ext(link: str) -> str:
     """primary doc 链接 → 保存扩展名。
 
@@ -1341,10 +1355,7 @@ class MStockAdapter(BaseStockAdapter):
             # os.environ.get("USER") 返回 None → None + str → TypeError.
             # META 26Q2 7-29 早上报这个错, download_status=FAILED.
             # 修: `or "Unknown"` 兜底, 跟 m_stock 其他 getattr 模式一致.
-            user = os.environ.get("USER") or "Unknown"
-            sec_ua = cfg.sec_user_agent or os.environ.get(
-                "SEC_USER_AGENT", f"{user}/contact@example.com Research Tool/1.0"
-            )
+            sec_ua = _resolve_sec_user_agent(cfg)
         headers = {
             "User-Agent": sec_ua,
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",

--- a/unified_downloader/infra/_babeldoc_wrapper.py
+++ b/unified_downloader/infra/_babeldoc_wrapper.py
@@ -49,6 +49,13 @@ def patch_babeldoc_translator():
 
 if __name__ == "__main__":
     patch_babeldoc_translator()
+    # W40-#50: API key 经环境变量传入 (父进程 argv 不含 key, ps 不可见);
+    # 这里补进 sys.argv 供 babeldoc 的 argparse 使用 — 进程已 exec,
+    # 运行期改 sys.argv 不会反映到内核 cmdline, ps 仍然不可见
+    import os
+    _key = os.environ.get("UNIFIED_DOWNLOADER_TRANSLATE_KEY", "")
+    if _key and "--openai-api-key" not in sys.argv:
+        sys.argv.extend(["--openai-api-key", _key])
     from babeldoc.main import main
     import asyncio
 

--- a/unified_downloader/infra/translator.py
+++ b/unified_downloader/infra/translator.py
@@ -112,17 +112,28 @@ class PDFTranslator:
         # 构建 babeldoc 命令
         # 使用 wrapper 脚本剥离推理模型输出中的 </think> 思考标签
         wrapper_path = Path(__file__).parent / "_babeldoc_wrapper.py"
-        if wrapper_path.exists():
+        use_wrapper = wrapper_path.exists()
+        if use_wrapper:
             babeldoc_cmd = [sys.executable, str(wrapper_path)]
         else:
             babeldoc_cmd = ["babeldoc"]
+            logger.warning(
+                "babeldoc wrapper 不存在, API key 将以命令行参数传给子进程 "
+                "(共享机器 ps 可见); 建议保留 _babeldoc_wrapper.py"
+            )
 
         cmd = babeldoc_cmd + [
             "--files", str(pdf_path),
             "--openai",
             "--openai-model", model,
             "--openai-base-url", base_url,
-            "--openai-api-key", api_key,
+        ]
+        if not use_wrapper:
+            # W40-#50: wrapper 存在时 key 经环境变量注入 (wrapper 的
+            # __main__ 里补进 sys.argv, 进程已 exec, ps 不可见);
+            # 仅 fallback 裸 babeldoc 时才进 argv
+            cmd += ["--openai-api-key", api_key]
+        cmd += [
             "--lang-in", "en",
             "--lang-out", target_lang,
             "--output", str(output_dir),
@@ -140,12 +151,20 @@ class PDFTranslator:
         logger.info(f"开始翻译: {pdf_path.name} (en→{target_lang})")
         translate_start_time = time.time()
 
+        run_env = None
+        if use_wrapper:
+            run_env = {
+                **os.environ,
+                "UNIFIED_DOWNLOADER_TRANSLATE_KEY": api_key,
+            }
+
         try:
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 timeout=1800,  # 30分钟超时
+                env=run_env,
             )
 
             if result.returncode != 0:


### PR DESCRIPTION
## 背景

#50 剩余快修项收官（路径统一已由 PR #58 解决 #49）。

## 修复内容

### B1. h_stock 年报/中报多檔案防护
之前只有招股书路径检查 `"多檔案" in file_info`，年报/中报的 `_download_report` 会把多檔案条目的索引页当正文下载。补齐同款检查返回 `MULTI_FILE`（含披露易人工查看链接）。此前 MULTI_FILE 零测试覆盖，本 PR 新增。

### B2. translator API key 移出子进程 argv
babeldoc 0.5.6 无 env 传参选项（已验证），但 key 在 argv 里 `ps aux` 可见。方案：仓库内 wrapper（`_babeldoc_wrapper.py`）存在时，key 经 `UNIFIED_DOWNLOADER_TRANSLATE_KEY` 环境变量传入子进程，wrapper 的 `__main__` 在进程 exec **之后**补进 `sys.argv`——内核 cmdline 已固定，ps 仍然不可见，而 babeldoc 的 argparse 正常拿到。裸 babeldoc fallback 保留 argv + warning（残留风险记 #50 待 babeldoc 升级）。

### B3. 三脚本副本统一（`scripts/bulk_common.py`）
`run`/`compute_summary`/`upload_ima`/IMA 脚本解析在三份脚本各有一份且语义漂移，统一到共享模块（**单一事实源**，函数显式传参保住测试 patch 面）：
- `compute_summary` 统一为 scheduler 严格版——bulk 的宽松语义被收紧（`downloaded` 且 ima 非失败才算 ok，`semantic_upload_rate_limited` 等非常规失败值计入失败）
- `upload_ima` 统一为完整判定版——fix 脚本的宽松 "✅ 出现" 会把 "✅ 成功 0" 判成功
- fix 脚本的 IMA 脚本解析从 env→legacy 换成完整查找链（env→repo→legacy）

### B4. 装饰性测试重写
- `test_m_stock_6k_size_fallback`：两个"测试里直接用内置 max() 自证"的用例 → 真实走 `_download_form` 的 size 回退路径（mock search + download_filing，断言实际选中的 filing）
- `test_m_stock_meta_nonetype`：两个"把被测表达式复制进断言"的用例 → 调用新抽出的 `_resolve_sec_user_agent()` 纯函数（三档优先级：config > SEC_USER_AGENT env > USER 兜底）
- 两个真实网络冒烟用例保留不动

## 测试

新增 `test_batch_b_polish.py` **6 用例**（MULTI_FILE 拒绝/正常路径不受影响、key 不在 argv 且在 env、严格 summary 语义、"成功 0"拒绝、三脚本接入 common）；全量 **254 passed**。

Refs #50（快修批勾选后 #50 全部收官）
