### PR TITLE
fix(#60): 6-K 季度窗口无 filing 时不回退跨季度 size 最大 — 明确失败

### DIFF
--- a/tests/test_6k_quarter_window_no_filing.py
+++ b/tests/test_6k_quarter_window_no_filing.py
@@ -1,0 +1,247 @@
+"""
+Regression tests for #60: 6-K 季度选择 bug — 目标季度窗口内无 filing 时
+size fallback 无视季度 → 选到错误季度财报.
+
+真实事故: DB id=136, PDD 2026Q2 实际下成 2025Q4 财报 (3/26 6-K).
+根因链:
+1. 6-K exhibit 描述全是通用 "EXHIBIT 99.1" → 无法区分季度 → 打分 0
+2. 目标季度窗口 (2026Q2 → 7/14~9/23) 内无 filing (8/21 财报缓存未收录)
+   → 窗口逻辑被跳过
+3. 核心 bug: 窗口失效后回退 max(filings, key=size) 选 size 最大 → 完全无视
+   季度 → 选中 3/26 (293067 > 212733)
+4. verifier 只验"是不是财报"不验"是不是这个季度" → 错误静默放行
+
+修复 (unified-downloader 侧):
+- _pick_earnings_6k 窗口边界硬约束: 有 report_period 且窗口内无 filing → 返回
+  None, 不再落到跨季度的旧逻辑
+- _download_form: _quarter_window_missed 命中时明确返回
+  NO_FILINGS_IN_QUARTER_WINDOW 失败 (含单条 6-K 情形), 绝不回退跨季度选文件
+
+这些测试只测选择/失败语义, 不下载真实文件.
+"""
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import (  # noqa: E402
+    MStockAdapter,
+    _quarter_window,
+    _quarter_window_missed,
+)
+
+
+def _mk_filing(accession: str, size: int, filed_at: str,
+               exhibits=None, name: str = ""):
+    """构造一条 filing dict（模拟 _search_edgar 返回, 通用 EXHIBIT 99.1 exhibit）."""
+    return {
+        "ticker": "PDD",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "1737806",
+        "companyName": name or accession,
+        "linkToTxt": f"https://example.com/{accession}/index.html",
+        "linkToHtml": f"https://example.com/{accession}/index.html",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits
+        or [{"url": f"https://example.com/{accession}/ex99.htm",
+             "description": "EXHIBIT 99.1",
+             "document": "tm1_ex99-1.htm"}],
+    }
+
+
+@pytest.fixture
+def adapter():
+    return MStockAdapter(MagicMock(), [])
+
+
+# ═══ 窗口工具函数 ═══
+
+
+class TestQuarterWindowHelpers:
+    def test_quarter_window_q2(self):
+        assert _quarter_window("2026Q2") == (date(2026, 7, 14), date(2026, 9, 23))
+
+    def test_quarter_window_none_for_no_period(self):
+        assert _quarter_window(None) is None
+        assert _quarter_window("nonsense") is None
+
+    def test_quarter_window_missed_true_when_empty(self):
+        filings = [
+            _mk_filing("MAR-Q4", 293067, "2026-03-26"),  # 窗口外 (2025Q4 财报, size 更大)
+            _mk_filing("JUL-PR", 60000, "2026-07-08"),   # 窗口外 (窗口 7/14 才开)
+        ]
+        assert _quarter_window_missed(filings, "2026Q2") is True
+
+    def test_quarter_window_missed_false_when_hit(self):
+        filings = [_mk_filing("AUG-Q2", 212733, "2026-08-13")]  # 窗口内
+        assert _quarter_window_missed(filings, "2026Q2") is False
+
+    def test_quarter_window_missed_false_without_period(self):
+        # 无 report_period → 无窗口约束 → 不算 miss (保持旧 size 回退语义)
+        filings = [_mk_filing("A", 1000, "2026-03-26")]
+        assert _quarter_window_missed(filings, None) is False
+
+
+# ═══ _pick_earnings_6k 窗口硬约束 ═══
+
+
+class TestPickEarningsWindowHardConstraint:
+    def test_window_empty_returns_none_not_cross_quarter(self, adapter):
+        """#60 核心: 窗口内无 filing → 返回 None, 绝不落到策略 2 选窗口外的 Q4.
+
+        修复前: 窗口为空 → 旧逻辑对 3/26 (293067) 等窗口外 exhibit 打分/回退,
+        选错季度. 修复后: 直接 None, 由 _download_form 明确失败.
+        """
+        filings = [
+            _mk_filing("MAR-Q4", 293067, "2026-03-26"),  # 2025Q4 财报, size 更大
+            _mk_filing("JUN-PR", 50000, "2026-06-15"),
+            _mk_filing("JUL-PR", 212733, "2026-07-08"),  # 窗口 7/14 前
+        ]
+        picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
+        assert picked is None
+
+    def test_window_hit_picks_in_window_even_if_outside_larger(self, adapter):
+        """窗口内命中 → 选窗口内 filing, 窗口外 size 更大的 3/26 不能赢."""
+        filings = [
+            _mk_filing("AUG-Q2", 212733, "2026-08-13"),   # 窗口内 (真 Q2)
+            _mk_filing("MAR-Q4", 293067, "2026-03-26"),   # 窗口外, size 更大
+            _mk_filing("JUL-PR", 50000, "2026-07-08"),
+        ]
+        picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "AUG-Q2"
+
+    def test_no_report_period_preserves_old_logic(self, adapter):
+        """无 report_period → 完全旧逻辑 (兼容 RACE/NVO)."""
+        filings = [
+            _mk_filing("A", 1000, "2026-08-13"),
+            _mk_filing("B", 2000, "2026-07-08"),
+        ]
+        assert adapter._pick_earnings_6k(filings) is None  # 全通用 exhibit → None
+
+
+# ═══ _download_form 失败语义 ═══
+
+
+class TestDownloadFormQuarterWindowMiss:
+    def test_window_miss_returns_failure_not_wrong_quarter(self, adapter):
+        """#60 核心事故复现: PDD 2026Q2, 窗口内无 filing → 明确失败,
+        绝不把 3/26 (2025Q4, size 更大) 下下来."""
+        filings = [
+            _mk_filing("MAR-Q4", 293067, "2026-03-26"),  # 旧逻辑会 max(size) 选它
+            _mk_filing("JUL-PR", 212733, "2026-07-08"),  # 窗口 (7/14) 前
+            _mk_filing("JUN-PR", 50000, "2026-06-15"),
+        ]
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is False
+        assert result.error_code == "NO_FILINGS_IN_QUARTER_WINDOW"
+        mock_dl.assert_not_called()  # 关键: 什么都没下载
+
+    def test_window_hit_still_downloads_in_window(self, adapter):
+        """窗口内有 filing → 正常下载窗口内的财报 (8/13), 而非 size 更大的 3/26."""
+        filings = [
+            _mk_filing("AUG-Q2", 212733, "2026-08-13"),  # 真 Q2 财报
+            _mk_filing("MAR-Q4", 293067, "2026-03-26"),  # size 更大但窗口外
+            _mk_filing("JUL-PR", 50000, "2026-07-08"),
+        ]
+        captured = {}
+        ok = MagicMock(success=True)
+
+        def fake_dl(filing, *args, **kw):
+            captured["filing"] = filing
+            return ok
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing", side_effect=fake_dl):
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is True
+        assert captured["filing"]["accessionNo"] == "AUG-Q2"
+        assert captured["filing"]["size"] == 212733
+
+    def test_single_filing_outside_window_fails(self, adapter):
+        """单条 6-K 也在窗口外 → 明确失败, 不硬下错误季度."""
+        filings = [_mk_filing("MAR-Q4", 293067, "2026-03-26")]
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is False
+        assert result.error_code == "NO_FILINGS_IN_QUARTER_WINDOW"
+        mock_dl.assert_not_called()
+
+    def test_single_filing_in_window_downloads(self, adapter):
+        """单条 6-K 在窗口内 → 正常下载."""
+        filings = [_mk_filing("AUG-Q2", 212733, "2026-08-13")]
+        captured = {}
+        ok = MagicMock(success=True)
+
+        def fake_dl(filing, *args, **kw):
+            captured["filing"] = filing
+            return ok
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing", side_effect=fake_dl):
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is True
+        assert captured["filing"]["accessionNo"] == "AUG-Q2"
+
+    def test_no_report_period_keeps_size_fallback(self, adapter):
+        """无 report_period → 保持 NVO 式 size 回退 (回归保护)."""
+        filings = [
+            _mk_filing("PR-BUYBACK", 167508, "2026-08-10"),
+            _mk_filing("FULL-EARN", 2784789, "2026-08-04"),  # size 最大
+        ]
+        captured = {}
+        ok = MagicMock(success=True)
+
+        def fake_dl(filing, *args, **kw):
+            captured["filing"] = filing
+            return ok
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing", side_effect=fake_dl):
+            result = adapter._download_form("NVO", "6-K", 2026, None, None)
+
+        assert result.success is True
+        assert captured["filing"]["accessionNo"] == "FULL-EARN"
+
+    def test_unparseable_report_period_keeps_size_fallback(self, adapter):
+        """report_period 无法解析出窗口 → 不启用硬约束, 保持 size 回退."""
+        filings = [
+            _mk_filing("PR-BUYBACK", 167508, "2026-08-10"),
+            _mk_filing("FULL-EARN", 2784789, "2026-08-04"),
+        ]
+        captured = {}
+        ok = MagicMock(success=True)
+
+        def fake_dl(filing, *args, **kw):
+            captured["filing"] = filing
+            return ok
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing", side_effect=fake_dl):
+            result = adapter._download_form(
+                "NVO", "6-K", 2026, None, None, report_period="not-a-period"
+            )
+
+        assert result.success is True
+        assert captured["filing"]["accessionNo"] == "FULL-EARN"

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -8,7 +8,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Callable
+from typing import Optional, List, Dict, Any, Callable, Tuple
 
 from unified_downloader.adapters.base import BaseStockAdapter
 from unified_downloader.models.enums import Market
@@ -56,6 +56,53 @@ def _report_period_target_end(report_period):
         return datetime.date(y, month_end, last_day)
     except Exception:
         return None
+
+
+# 目标季度财报发布窗口: 报告期结束后 [QUARTER_EARLY_DAYS, QUARTER_LATE_DAYS] 天
+# W40-#50 真实数据验证 (TSM): Q4 财报最早 ~16 天就发布 (次年 1 月中旬),
+# 25 天会漏; 14 天与相邻季度窗口 (Q3 止 12-24) 仍无重叠
+QUARTER_EARLY_DAYS = 14
+QUARTER_LATE_DAYS = 85  # 最晚在 ~85 天内 (跨季末但未到下一季末)
+
+
+def _filing_filed_date(f: Dict[str, Any]) -> Optional[datetime.date]:
+    """filing dict → filedAt 日期 (兼容 str / date)."""
+    raw = f.get("filedAt") or f.get("filing_date") or ""
+    if isinstance(raw, datetime.date):
+        return raw
+    try:
+        return datetime.date.fromisoformat(str(raw)[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def _quarter_window(report_period: Optional[str]) -> Optional[Tuple[datetime.date, datetime.date]]:
+    """report_period → 目标季度窗口 (window_lo, window_hi); 无法解析返回 None."""
+    target_end = _report_period_target_end(report_period)
+    if target_end is None:
+        return None
+    lo = target_end + datetime.timedelta(days=QUARTER_EARLY_DAYS)
+    hi = target_end + datetime.timedelta(days=QUARTER_LATE_DAYS)
+    return lo, hi
+
+
+def _quarter_window_missed(
+    filings: List[Dict[str, Any]], report_period: Optional[str]
+) -> bool:
+    """目标报告期有可解析窗口, 但 filings 里没有一条落在窗口内.
+
+    #60 修复: 命中表示目标季度财报未发布 / 搜索缓存未收录 — 调用方应明确失败,
+    绝不能回退按 size 选别的季度财报 (PDD 2026Q2 下成 2025Q4 3/26 的根因).
+    """
+    window = _quarter_window(report_period)
+    if window is None:
+        return False
+    lo, hi = window
+    for f in filings:
+        d = _filing_filed_date(f)
+        if d is not None and lo <= d <= hi:
+            return False
+    return True
 
 
 def _resolve_sec_user_agent(cfg) -> str:
@@ -605,6 +652,19 @@ class MStockAdapter(BaseStockAdapter):
                 picked = self._pick_earnings_6k(filings, report_period=report_period)
                 if picked is not None:
                     filing = picked
+                elif _quarter_window_missed(filings, report_period):
+                    # #60: 有目标报告期 (如 2026Q2) 且窗口可解析, 但窗口内无任何
+                    # filing (财报未发布 / 搜索缓存未收录). 旧逻辑回退 max(size)
+                    # 完全无视季度 → 选到别的季度财报 (PDD 2026Q2 实际下成 2025Q4
+                    # 3/26, 293067 > 212733) → 明确失败, 等财报收录后重跑.
+                    return DownloadResult(
+                        success=False,
+                        error_code="NO_FILINGS_IN_QUARTER_WINDOW",
+                        error_message=(
+                            f"{ticker} {report_period} 目标季度窗口内无 6-K 财报 "
+                            f"filing (财报可能未发布或搜索缓存未收录), 未下载任何文件"
+                        ),
+                    )
                 else:
                     # 2026-08-13 NVO 修复: _pick_earnings_6k 对“单文档 6-K”
                     # (NVO 等, 正文=primary doc, 无独立 EX-99 exhibit) 无 exhibit
@@ -612,6 +672,8 @@ class MStockAdapter(BaseStockAdapter):
                     # 会抓到普通公告 (NVO 8-10 股票回购 24KB) 而非 8-4 完整财报
                     # (caq22026.htm 1.73MB). 改为选 size 最大的 filing (财报正文
                     # 通常远大于普通公告/回购公告), 避免 SUSPICIOUS_TOO_SMALL.
+                    # 该回退只在无 report_period (无目标窗口) 时生效 — 有窗口时
+                    # 上面的 _quarter_window_missed 已拦截, 不会跨季度乱选 (#60).
                     best = max(
                         filings, key=lambda f: int(f.get("size") or 0)
                     )
@@ -623,6 +685,22 @@ class MStockAdapter(BaseStockAdapter):
                             f"size={filing.get('size')})"
                         )
                         filing = best
+            elif (
+                form_type == "6-K"
+                and len(filings) == 1
+                and _quarter_window_missed(filings, report_period)
+            ):
+                # #60: 单条 6-K 也要受目标季度窗口硬约束 — 仅剩的一条不在窗口内
+                # (例如缓存里只有 3 月发布的上一季度财报) 同样明确失败, 不硬下
+                # 错误季度的文件.
+                return DownloadResult(
+                    success=False,
+                    error_code="NO_FILINGS_IN_QUARTER_WINDOW",
+                    error_message=(
+                        f"{ticker} {report_period} 目标季度窗口内无 6-K 财报 filing "
+                        f"(仅命中窗口外 {filing.get('filedAt')}), 未下载任何文件"
+                    ),
+                )
 
             return self._download_filing(
                 filing, ticker, form_type, year, on_progress, checkpoint
@@ -682,26 +760,17 @@ class MStockAdapter(BaseStockAdapter):
            天窗口内的 filing 优先. 窗口内选 exhibit 打分最高的; 若窗口内
            全无 exhibit 可打分, 选窗口内 size 最大的. 这保证 XNET 选到
            8-13 的 Q2 (窗口 ~7-30~9-18) 而不是 3-12 的 Q4.
-        2. 无 report_period 或窗口无命中 → 回退旧逻辑 (打分 → None).
+        2. #60 硬约束: 有可解析窗口但窗口内无任何 filing (财报未发布/搜索
+           缓存未收录) → 直接返回 None, 不再落进跨季度的旧逻辑 — 由
+           _download_form 明确失败, 绝不回退选别的季度财报 (PDD 2026Q2
+           下成 2025Q4 3/26 的根因).
+        3. 无 report_period 或无法解析 → 回退旧逻辑 (打分 → None).
         """
-        # 目标季度窗口 (季度结束后第 N~M 天发布财报)
-        # W40-#50 真实数据验证 (TSM): Q4 财报最早 ~16 天就发布 (次年 1 月
-        # 中旬), 25 天会漏; 14 天与相邻季度窗口 (Q3 止 12-24) 仍无重叠
-        QUARTER_EARLY_DAYS = 14
-        QUARTER_LATE_DAYS = 85    # 最晚在 ~85 天内 (跨季末但未到下一季末)
-
+        # 目标季度窗口 (季度结束后第 N~M 天发布财报): 常量提到模块级
+        # (QUARTER_EARLY_DAYS / QUARTER_LATE_DAYS), _download_form 也要用.
         # 解析 report_period → 目标报告期结束日 (W40-#50: 抽出共用 helper,
         # 同步修复 H1/H2 按季度映射错一个季度的 bug)
         target_end = _report_period_target_end(report_period)
-
-        def _filed_at_date(f: Dict[str, Any]) -> Optional[datetime.date]:
-            raw = f.get("filedAt") or f.get("filing_date") or ""
-            if isinstance(raw, datetime.date):
-                return raw
-            try:
-                return datetime.date.fromisoformat(str(raw)[:10])
-            except (ValueError, TypeError):
-                return None
 
         def _exhibit_score(f: Dict[str, Any]) -> int:
             """计算 filing 的 exhibit 财报特征分 (旧逻辑)."""
@@ -717,13 +786,13 @@ class MStockAdapter(BaseStockAdapter):
                     score += 1 if ex_size > 100_000 else 0
             return score
 
-        # ── 策略 1: 目标季度日期窗口优先 ──
+        # ── 策略 1: 目标季度日期窗口优先 (窗口边界硬约束, #60) ──
         if target_end is not None:
             window_lo = target_end + datetime.timedelta(days=QUARTER_EARLY_DAYS)
             window_hi = target_end + datetime.timedelta(days=QUARTER_LATE_DAYS)
             in_window = []
             for f in filings:
-                d = _filed_at_date(f)
+                d = _filing_filed_date(f)
                 if d is None:
                     continue
                 if window_lo <= d <= window_hi:
@@ -754,7 +823,17 @@ class MStockAdapter(BaseStockAdapter):
                 )
                 return best_in
 
-        # ── 策略 2: 旧逻辑 (exhibit 打分, 无窗口) ──
+            # #60: 窗口内无任何 filing → 直接返回 None, 不再落进下面的策略 2
+            # (旧逻辑会对窗口外其他季度的 exhibit 打分 / 按 size 选, 同样会
+            # 选错季度 — PDD 2026Q2 下成 2025Q4 3/26 的根因). 目标季度财报
+            # 未发布/未收录时, 由 _download_form 明确失败处理.
+            logger.info(
+                f"[m_stock] 6-K 目标季度窗口 {window_lo}~{window_hi} 内无 filing, "
+                f"返回 None (财报未发布或未收录), 不跨季度选文件"
+            )
+            return None
+
+        # ── 策略 2: 旧逻辑 (exhibit 打分, 无窗口) — 仅无 report_period / 无法解析 ──
         best = None
         best_score = -1
         for filing in filings:


### PR DESCRIPTION
## 问题 (#60)

DB id=136 标 PDD 2026Q2，实下到 2025Q4 财报（3/26 6-K）—— 系统连季度都没选对。

**根因链（4 环节，逐层验证）：**
1. 6-K exhibit 描述全是通用 `EXHIBIT 99.1` → 无法区分季度 → 打分 0
2. 目标季度窗口（如 2026Q2 → 7/14~9/23）内无 filing（财报未发布 / 8/21 搜索缓存未收录）→ 窗口逻辑被跳过
3. **核心 bug**：窗口失效后 `_download_form` 回退 `max(filings, key=size)` 选 size 最大 → **完全无视季度** → 选中 3/26（293067 > 212733）
4. verifier 只验"是不是财报"不验"是不是这个季度" → 错误静默放行

## 修复

**`unified_downloader/adapters/m_stock.py`**
- `_pick_earnings_6k` 窗口边界硬约束：有可解析 `report_period` 但窗口内无 filing → 直接返回 None，不再落进跨季度的旧逻辑（旧逻辑会对窗口外其他季度 exhibit 打分，同样可能选错季度）
- `_download_form`：`_quarter_window_missed` 命中时明确返回 `NO_FILINGS_IN_QUARTER_WINDOW` 失败（含单条 6-K 情形），绝不回退选别的季度财报 → 对应"财报未发布应等待"，不会把错误季度入库
- 无 `report_period`（NVO 单文档 6-K）时保留原 size 回退语义，不破坏既有行为
- 窗口常量提升到模块级，新增 helper：`_filing_filed_date` / `_quarter_window` / `_quarter_window_missed`

**新增回归测试 `tests/test_6k_quarter_window_no_filing.py`（14 用例）**
- PDD 场景复现：Q2 窗口空 → 明确失败，不下载 3/26 的 2025Q4
- 窗口内命中不受窗口外 size 更大的文件干扰
- 单条 6-K 内外窗口、无 report_period / 无法解析时保留 size 回退

## 验证
- 全量测试套件 **268 passed**（含 24 个既有 6-K 用例 + 14 个新用例）
- 端到端复现 PDD 场景：确认不再下载 2025Q4，返回 `NO_FILINGS_IN_QUARTER_WINDOW`
- ruff 无新增告警（3 个既有 F401/F841 在改动前已存在，未触碰）

## 后续（不在本 PR 范围）
- issue 第 4 条 "verifier 加季度一致性校验" 在 `morning-brief` 项目（`download_verifier.py`），需单独处理
- `scripts/bulk_download.py` 美股季报走粗粒度 "Q1-Q3" 标签、不传 `--report-period`，批量路径仍走旧选择逻辑；如需批量启用季度窗口需另行接入

Closes #60