### PR TITLE
fix(#62): 6-K 窗口内只有非财报公告时不下载 — size 下限防御

### DIFF
--- a/tests/test_6k_window_non_earnings_announcement.py
+++ b/tests/test_6k_window_non_earnings_announcement.py
@@ -1,0 +1,176 @@
+"""
+Regression tests for #62: 6-K 季度窗口内只有非财报公告时不再下载公告.
+
+真实事故 (2026-08-24 实测): 修复 #60 后重跑 PDD 2026Q2, 窗口 (7/14~9/23)
+命中 8/21 的「董事去世公告」(6-K, 11.1KB, exhibit 描述通用 "EXHIBIT 99.1" 全
+0 分) → 旧逻辑"全 0 分选窗口内 size 最大"把它下下来 ( downloads/m/PDD/
+PDD_2026_6K.html 11.1KB ), 依赖 morning-brief verifier 兜底拦截.
+
+修复: 窗口内 exhibit 全 0 分时, size 最大者必须 ≥ MIN_EARNINGS_FILING_SIZE
+(50KB, 真实财报 200KB+ vs 公告 <45KB) 才接受; 全部低于下限 = 窗口内只有
+非财报公告 → _pick_earnings_6k 返回 None → _download_form 明确失败
+NO_FILINGS_IN_QUARTER_WINDOW (等真财报), 而不是下载公告.
+
+这些测试只测选择/失败语义, 不下载真实文件.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import (  # noqa: E402
+    MStockAdapter,
+    MIN_EARNINGS_FILING_SIZE,
+)
+
+
+def _mk_filing(accession: str, size: int, filed_at: str,
+               exhibits=None, name: str = ""):
+    """构造一条 filing dict（模拟 _search_edgar 返回, 默认通用 EXHIBIT 99.1）."""
+    return {
+        "ticker": "PDD",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "1737806",
+        "companyName": name or accession,
+        "linkToTxt": f"https://example.com/{accession}/index.html",
+        "linkToHtml": f"https://example.com/{accession}/index.html",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits
+        or [{"url": f"https://example.com/{accession}/ex99.htm",
+             "description": "EXHIBIT 99.1",
+             "document": "tm1_ex99-1.htm"}],
+    }
+
+
+@pytest.fixture
+def adapter():
+    return MStockAdapter(MagicMock(), [])
+
+
+class TestPickEarningsNonEarningsGate:
+    def test_window_only_announcement_returns_none(self, adapter):
+        """#62 核心: 窗口内只有 11.1KB 董事去世公告 → 返回 None, 不下载."""
+        filings = [
+            _mk_filing("AUG-DEATH-NOTICE", 11366, "2026-08-21"),  # 董事去世公告
+            _mk_filing("JUL-PR", 30000, "2026-07-20"),            # 窗口内小 PR
+        ]
+        picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
+        assert picked is None
+
+    def test_window_announcement_plus_large_generic_picks_large(self, adapter):
+        """窗口内公告 + 大的通用 exhibit 财报 → 选大的那个 (旧语义保留)."""
+        filings = [
+            _mk_filing("AUG-DEATH-NOTICE", 11366, "2026-08-21"),
+            _mk_filing("AUG-Q2-EARN", 212733, "2026-08-21"),  # 真财报, 同日
+        ]
+        picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "AUG-Q2-EARN"
+
+    def test_keyword_scored_tiny_filing_still_accepted(self, adapter):
+        """exhibit 有关键词命中 (打分 >0) → 即使 size 小也接受 (关键词可信)."""
+        scored_tiny = _mk_filing(
+            "AUG-EARN-PR", 15000, "2026-08-21",
+            exhibits=[{
+                "url": "https://x/q2results.htm",
+                "description": "Second Quarter 2026 Financial Results",
+                "document": "q2results.htm",
+            }],
+        )
+        picked = adapter._pick_earnings_6k([scored_tiny], report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "AUG-EARN-PR"
+
+    def test_size_unknown_keeps_old_behavior(self, adapter):
+        """size 全部未知 (0/None, 兼容无 size 数据源) → 接受窗口内最大者."""
+        filings = [_mk_filing("A", 0, "2026-08-21")]
+        picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "A"
+
+    def test_threshold_boundary(self, adapter):
+        """下限边界: 低于 MIN_EARNINGS_FILING_SIZE 拒绝, 等于则接受."""
+        below = _mk_filing("BELOW", MIN_EARNINGS_FILING_SIZE - 1, "2026-08-21")
+        assert adapter._pick_earnings_6k([below], report_period="2026Q2") is None
+
+        at_min = _mk_filing("AT-MIN", MIN_EARNINGS_FILING_SIZE, "2026-08-21")
+        picked = adapter._pick_earnings_6k([at_min], report_period="2026Q2")
+        assert picked is not None
+        assert picked["accessionNo"] == "AT-MIN"
+
+
+class TestDownloadFormNonEarningsGate:
+    def test_window_only_announcement_fails_not_downloads(self, adapter):
+        """#62 核心事故复现: 窗口内只有 8/21 公告 → 明确失败, 不下载公告."""
+        filings = [
+            _mk_filing("AUG-DEATH-NOTICE", 11366, "2026-08-21"),
+            _mk_filing("JUL-PR", 30000, "2026-07-20"),
+        ]
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is False
+        assert result.error_code == "NO_FILINGS_IN_QUARTER_WINDOW"
+        # 区分 #60 (窗口内无 filing) vs #62 (窗口内只有公告)
+        assert "非财报公告" in result.error_message
+        mock_dl.assert_not_called()  # 关键: 公告没被下载
+
+    def test_window_miss_message_distinguishes_empty_window(self, adapter):
+        """#60 场景报"窗口内无 filing", 与 #62 的"只有非财报公告"区分."""
+        filings = [
+            _mk_filing("MAR-Q4", 293067, "2026-03-26"),  # 窗口外
+            _mk_filing("JUL-PR", 30000, "2026-07-08"),   # 窗口 (7/14) 前
+        ]
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is False
+        assert result.error_code == "NO_FILINGS_IN_QUARTER_WINDOW"
+        assert "窗口内无 filing" in result.error_message
+        mock_dl.assert_not_called()
+
+    def test_real_earnings_in_window_still_downloads(self, adapter):
+        """窗口内出现真财报 (200KB+) → 正常下载, 不被防御误伤."""
+        filings = [
+            _mk_filing("AUG-DEATH-NOTICE", 11366, "2026-08-21"),
+            _mk_filing("AUG-Q2-EARN", 212733, "2026-08-21"),  # 财报盘后入库
+        ]
+        captured = {}
+        ok = MagicMock(success=True)
+
+        def fake_dl(filing, *args, **kw):
+            captured["filing"] = filing
+            return ok
+
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing", side_effect=fake_dl):
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is True
+        assert captured["filing"]["accessionNo"] == "AUG-Q2-EARN"
+
+    def test_single_tiny_in_window_fails(self, adapter):
+        """单条窗口内小公告 (真实场景: 财报未出, 缓存只有 8/21 公告) → 失败."""
+        filings = [_mk_filing("AUG-DEATH-NOTICE", 11366, "2026-08-21")]
+        with patch.object(adapter, "_search_filings", return_value=filings), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is False
+        assert result.error_code == "NO_FILINGS_IN_QUARTER_WINDOW"
+        mock_dl.assert_not_called()

--- a/tests/test_6k_window_non_earnings_announcement.py
+++ b/tests/test_6k_window_non_earnings_announcement.py
@@ -86,12 +86,41 @@ class TestPickEarningsNonEarningsGate:
         assert picked is not None
         assert picked["accessionNo"] == "AUG-EARN-PR"
 
-    def test_size_unknown_keeps_old_behavior(self, adapter):
-        """size 全部未知 (0/None, 兼容无 size 数据源) → 接受窗口内最大者."""
+    def test_size_unknown_fails_closed(self, adapter):
+        """size 未知 (sec-api 兜底路径无 size 字段) → fail-closed 返回 None.
+
+        PR #63 review 实证: sec-api filings 无 size/_exhibits, size=0 被当
+        "未知→接受" 会让 PDD 8/21 公告场景在该路径照旧下载 — 无法证明"像
+        财报"时宁可失败等可证数据, 不赌下载.
+        """
         filings = [_mk_filing("A", 0, "2026-08-21")]
         picked = adapter._pick_earnings_6k(filings, report_period="2026Q2")
-        assert picked is not None
-        assert picked["accessionNo"] == "A"
+        assert picked is None
+
+    def test_sec_api_shaped_filing_without_size_not_downloaded(self, adapter):
+        """#62 review 复现: sec-api 形态 filing (无 size 无 _exhibits) 在窗口内
+        → _download_form 明确失败, 不下载."""
+        sec_api_filing = {
+            "ticker": "PDD",
+            "formType": "6-K",
+            "filedAt": "2026-08-21T00:00:00",
+            "accessionNo": "0001193125-26-000123",
+            "cik": "1737806",
+            "companyName": "PDD Holdings Inc.",
+            "description": "Announcement of death of director",
+            "linkToTxt": "https://example.com/x.htm",
+            "linkToHtml": "https://example.com/x.htm",
+            "source": "sec_api",
+        }
+        with patch.object(adapter, "_search_filings", return_value=[sec_api_filing]), \
+             patch.object(adapter, "_download_filing") as mock_dl:
+            result = adapter._download_form(
+                "PDD", "6-K", 2026, None, None, report_period="2026Q2"
+            )
+
+        assert result.success is False
+        assert result.error_code == "NO_FILINGS_IN_QUARTER_WINDOW"
+        mock_dl.assert_not_called()
 
     def test_threshold_boundary(self, adapter):
         """下限边界: 低于 MIN_EARNINGS_FILING_SIZE 拒绝, 等于则接受."""

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -64,6 +64,13 @@ def _report_period_target_end(report_period):
 QUARTER_EARLY_DAYS = 14
 QUARTER_LATE_DAYS = 85  # 最晚在 ~85 天内 (跨季末但未到下一季末)
 
+# #62: 窗口内 exhibit 全 0 分时, "像一份财报" 的 filing size 下限.
+# 依据: 非财报公告常 <45KB (PDD 8/21 董事去世公告 11.1KB / RACE PR 3KB /
+# XNET 普通公告 17~45KB), 而真实财报 filing 200KB+ (PDD Q2 212733 /
+# XNET Q2 206088 / RACE 中报 209000 / NVO 1.73MB). 窗口内最大 size 低于
+# 此值 = 窗口内只有非财报公告 → 不下载 (返回 None 由调用方明确失败).
+MIN_EARNINGS_FILING_SIZE = 50_000
+
 
 def _filing_filed_date(f: Dict[str, Any]) -> Optional[datetime.date]:
     """filing dict → filedAt 日期 (兼容 str / date)."""
@@ -648,23 +655,36 @@ class MStockAdapter(BaseStockAdapter):
                 return _try_ir_fallback()
 
             filing = filings[0]
-            if form_type == "6-K" and len(filings) > 1:
+            if form_type == "6-K" and _quarter_window(report_period) is not None:
+                # #60/#62: report_period 可解析出目标季度窗口时, 6-K 选择全权交给
+                # _pick_earnings_6k (含单条 filing). 返回 None = 窗口内无 filing
+                # (#60: 财报未发布/缓存未收录, 旧逻辑回退 max(size) 跨季度错选,
+                # PDD 2026Q2 下成 2025Q4 3/26) 或窗口内只有非财报公告 (#62: 全
+                # 0 分且 size 低于财报下限, PDD 8/21 董事去世公告 11.1KB) →
+                # 明确失败等真财报, 绝不回退跨季度 size 最大, 也不下载公告.
                 picked = self._pick_earnings_6k(filings, report_period=report_period)
-                if picked is not None:
-                    filing = picked
-                elif _quarter_window_missed(filings, report_period):
-                    # #60: 有目标报告期 (如 2026Q2) 且窗口可解析, 但窗口内无任何
-                    # filing (财报未发布 / 搜索缓存未收录). 旧逻辑回退 max(size)
-                    # 完全无视季度 → 选到别的季度财报 (PDD 2026Q2 实际下成 2025Q4
-                    # 3/26, 293067 > 212733) → 明确失败, 等财报收录后重跑.
+                if picked is None:
+                    if _quarter_window_missed(filings, report_period):
+                        detail = "窗口内无 filing, 财报可能未发布或搜索缓存未收录"
+                    else:
+                        detail = (
+                            "窗口内只有非财报公告 (exhibit 无财报特征且 size 低于"
+                            f"财报下限 {MIN_EARNINGS_FILING_SIZE}B)"
+                        )
                     return DownloadResult(
                         success=False,
                         error_code="NO_FILINGS_IN_QUARTER_WINDOW",
                         error_message=(
-                            f"{ticker} {report_period} 目标季度窗口内无 6-K 财报 "
-                            f"filing (财报可能未发布或搜索缓存未收录), 未下载任何文件"
+                            f"{ticker} {report_period} 目标季度窗口内无可信 6-K 财报 "
+                            f"filing ({detail}), 未下载任何文件"
                         ),
                     )
+                filing = picked
+            elif form_type == "6-K" and len(filings) > 1:
+                # 无 report_period (或无法解析) → 旧逻辑: 打分优先, NVO size 回退.
+                picked = self._pick_earnings_6k(filings, report_period=report_period)
+                if picked is not None:
+                    filing = picked
                 else:
                     # 2026-08-13 NVO 修复: _pick_earnings_6k 对“单文档 6-K”
                     # (NVO 等, 正文=primary doc, 无独立 EX-99 exhibit) 无 exhibit
@@ -672,8 +692,8 @@ class MStockAdapter(BaseStockAdapter):
                     # 会抓到普通公告 (NVO 8-10 股票回购 24KB) 而非 8-4 完整财报
                     # (caq22026.htm 1.73MB). 改为选 size 最大的 filing (财报正文
                     # 通常远大于普通公告/回购公告), 避免 SUSPICIOUS_TOO_SMALL.
-                    # 该回退只在无 report_period (无目标窗口) 时生效 — 有窗口时
-                    # 上面的 _quarter_window_missed 已拦截, 不会跨季度乱选 (#60).
+                    # 该回退只在无目标窗口时生效 — 有窗口时上面的分支已按季度
+                    # 硬约束拦截 (#60/#62), 不会跨季度/选到非财报公告.
                     best = max(
                         filings, key=lambda f: int(f.get("size") or 0)
                     )
@@ -685,22 +705,6 @@ class MStockAdapter(BaseStockAdapter):
                             f"size={filing.get('size')})"
                         )
                         filing = best
-            elif (
-                form_type == "6-K"
-                and len(filings) == 1
-                and _quarter_window_missed(filings, report_period)
-            ):
-                # #60: 单条 6-K 也要受目标季度窗口硬约束 — 仅剩的一条不在窗口内
-                # (例如缓存里只有 3 月发布的上一季度财报) 同样明确失败, 不硬下
-                # 错误季度的文件.
-                return DownloadResult(
-                    success=False,
-                    error_code="NO_FILINGS_IN_QUARTER_WINDOW",
-                    error_message=(
-                        f"{ticker} {report_period} 目标季度窗口内无 6-K 财报 filing "
-                        f"(仅命中窗口外 {filing.get('filedAt')}), 未下载任何文件"
-                    ),
-                )
 
             return self._download_filing(
                 filing, ticker, form_type, year, on_progress, checkpoint
@@ -754,7 +758,7 @@ class MStockAdapter(BaseStockAdapter):
         目标季度 (XNET Q2 8-13 发布 size=206088, Q4+FY2025 3-12 发布
         size=244676 更大 → 误选 Q4).
 
-        修复策略 (两层):
+        修复策略 (三层):
         1. 若传了 report_period (如 "2026Q2") 且能解析出目标季度 → 用
            filedAt 日期窗口优先匹配: 目标季度结束日 + [EARLY_DAYS, LATE_DAYS]
            天窗口内的 filing 优先. 窗口内选 exhibit 打分最高的; 若窗口内
@@ -764,7 +768,11 @@ class MStockAdapter(BaseStockAdapter):
            缓存未收录) → 直接返回 None, 不再落进跨季度的旧逻辑 — 由
            _download_form 明确失败, 绝不回退选别的季度财报 (PDD 2026Q2
            下成 2025Q4 3/26 的根因).
-        3. 无 report_period 或无法解析 → 回退旧逻辑 (打分 → None).
+        3. #62 非财报防御: 窗口内 exhibit 全 0 分时, size 最大者必须 ≥
+           MIN_EARNINGS_FILING_SIZE (50KB) 才接受; 已知 size 且全部低于下限
+           = 窗口内只有非财报公告 (PDD 8/21 董事去世公告 11.1KB 实测) →
+           返回 None, 由 _download_form 明确失败等真财报, 而非下载公告.
+        4. 无 report_period 或无法解析 → 回退旧逻辑 (打分 → None).
         """
         # 目标季度窗口 (季度结束后第 N~M 天发布财报): 常量提到模块级
         # (QUARTER_EARLY_DAYS / QUARTER_LATE_DAYS), _download_form 也要用.
@@ -813,10 +821,23 @@ class MStockAdapter(BaseStockAdapter):
                         best_in = f
                 if best_score_in > 0:
                     return best_in
-                # 全无 exhibit 可打分 → 选窗口内 size 最大
+                # 全无 exhibit 可打分 → 选窗口内 size 最大, 但先过"像不像财报"
+                # 下限 (#62): 窗口内常混有非财报公告 (董事变动/PR), 财报 filing
+                # 通常 ≥ MIN_EARNINGS_FILING_SIZE (50KB). 已知 size 且最大值仍
+                # 低于下限 = 窗口内只有非财报公告 → 返回 None 等真财报, 不下载.
+                # (size 全部未知/0 时无法判定, 保持旧行为接受, 兼容无 size 数据源.)
                 best_in = max(
                     in_window, key=lambda f: int(f.get("size") or 0)
                 )
+                best_size_in = int(best_in.get("size") or 0)
+                if 0 < best_size_in < MIN_EARNINGS_FILING_SIZE:
+                    logger.info(
+                        f"[m_stock] 6-K 窗口内 exhibit 全 0 分且最大 size="
+                        f"{best_size_in} < {MIN_EARNINGS_FILING_SIZE} "
+                        f"(疑似非财报公告, PDD 8/21 董事去世公告 11.1KB 实测), "
+                        f"返回 None 等真财报"
+                    )
+                    return None
                 logger.info(
                     f"[m_stock] 6-K 窗口内无 exhibit 财报分, 选 size 最大: "
                     f"{best_in.get('accessionNo')} size={best_in.get('size')}"

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -768,10 +768,11 @@ class MStockAdapter(BaseStockAdapter):
            缓存未收录) → 直接返回 None, 不再落进跨季度的旧逻辑 — 由
            _download_form 明确失败, 绝不回退选别的季度财报 (PDD 2026Q2
            下成 2025Q4 3/26 的根因).
-        3. #62 非财报防御: 窗口内 exhibit 全 0 分时, size 最大者必须 ≥
-           MIN_EARNINGS_FILING_SIZE (50KB) 才接受; 已知 size 且全部低于下限
-           = 窗口内只有非财报公告 (PDD 8/21 董事去世公告 11.1KB 实测) →
-           返回 None, 由 _download_form 明确失败等真财报, 而非下载公告.
+        3. #62 非财报防御 (fail-closed): 窗口内 exhibit 全 0 分时, size 最大者
+           必须 ≥ MIN_EARNINGS_FILING_SIZE (50KB) 才接受. 已知 size 且全部低于
+           下限 = 窗口内只有非财报公告 (PDD 8/21 董事去世公告 11.1KB 实测);
+           size 未知 (sec-api 兜底路径 filings 无 size 字段) = 无法证明"像财报"
+           — 两者都返回 None, 由 _download_form 明确失败等真财报, 而非下载公告.
         4. 无 report_period 或无法解析 → 回退旧逻辑 (打分 → None).
         """
         # 目标季度窗口 (季度结束后第 N~M 天发布财报): 常量提到模块级
@@ -823,20 +824,29 @@ class MStockAdapter(BaseStockAdapter):
                     return best_in
                 # 全无 exhibit 可打分 → 选窗口内 size 最大, 但先过"像不像财报"
                 # 下限 (#62): 窗口内常混有非财报公告 (董事变动/PR), 财报 filing
-                # 通常 ≥ MIN_EARNINGS_FILING_SIZE (50KB). 已知 size 且最大值仍
-                # 低于下限 = 窗口内只有非财报公告 → 返回 None 等真财报, 不下载.
-                # (size 全部未知/0 时无法判定, 保持旧行为接受, 兼容无 size 数据源.)
+                # 通常 ≥ MIN_EARNINGS_FILING_SIZE (50KB). fail-closed 双拦截:
+                #   - 已知 size 且低于下限 = 疑似非财报公告 → 拒绝
+                #   - size 未知 (sec-api 兜底路径 filings 无 size 字段) 且无
+                #     exhibit 特征 = 无法证明"像财报" → 同样拒绝, 不赌下载
+                #     (PDD 8/21 公告经 sec-api 路径复现过, PR #63 review 实证).
                 best_in = max(
                     in_window, key=lambda f: int(f.get("size") or 0)
                 )
                 best_size_in = int(best_in.get("size") or 0)
-                if 0 < best_size_in < MIN_EARNINGS_FILING_SIZE:
-                    logger.info(
-                        f"[m_stock] 6-K 窗口内 exhibit 全 0 分且最大 size="
-                        f"{best_size_in} < {MIN_EARNINGS_FILING_SIZE} "
-                        f"(疑似非财报公告, PDD 8/21 董事去世公告 11.1KB 实测), "
-                        f"返回 None 等真财报"
-                    )
+                if best_size_in < MIN_EARNINGS_FILING_SIZE:
+                    if best_size_in > 0:
+                        logger.info(
+                            f"[m_stock] 6-K 窗口内 exhibit 全 0 分且最大 size="
+                            f"{best_size_in} < {MIN_EARNINGS_FILING_SIZE} "
+                            f"(疑似非财报公告, PDD 8/21 董事去世公告 11.1KB 实测), "
+                            f"返回 None 等真财报"
+                        )
+                    else:
+                        logger.info(
+                            f"[m_stock] 6-K 窗口内 exhibit 全 0 分且 filing size 未知 "
+                            f"(疑似 sec-api 兜底路径, 无 size 字段), 无法验证财报特征, "
+                            f"返回 None 等可证数据 (edgar 恢复/财报入库)"
+                        )
                     return None
                 logger.info(
                     f"[m_stock] 6-K 窗口内无 exhibit 财报分, 选 size 最大: "


### PR DESCRIPTION
## 问题 (#62)

修复 #60 后重跑 PDD 2026Q2：窗口（7/14~9/23）命中 8/21 的「董事去世公告」（6-K，11.1KB，exhibit 描述全通用 `EXHIBIT 99.1` → 打分全 0），旧逻辑"窗口内全 0 分选 size 最大"把它下下来——依赖 morning-brief verifier 兜底（SUSPICIOUS_NO_KEYWORDS），源头无防御。

## 修复

**`unified_downloader/adapters/m_stock.py`**
- 新增 `MIN_EARNINGS_FILING_SIZE = 50_000`：真实财报 filing 200KB+（PDD Q2 212733 / XNET Q2 206088 / RACE 中报 209000 / NVO 1.73MB），非财报公告 <45KB（PDD 董事去世公告 11.1KB / RACE PR 3KB / XNET 公告 17~45KB）
- `_pick_earnings_6k`：窗口内 exhibit 全 0 分时，size 最大者 ≥50KB 才接受；已知 size 且全部低于下限 = 窗口内只有非财报公告 → 返回 None 等真财报（size 全未知/0 时保持旧行为，兼容无 size 数据源；关键词命中打分 >0 的小文件仍接受）
- `_download_form`：report_period 可解析窗口时选择全权交给 `_pick_earnings_6k`（含单条 filing，原单条分支合并），None → `NO_FILINGS_IN_QUARTER_WINDOW` 明确失败，错误信息区分 **"窗口内无 filing"（#60）vs "窗口内只有非财报公告"（#62）**
- 无 report_period（NVO）路径不受影响

**新增回归测试 `tests/test_6k_window_non_earnings_announcement.py`（9 用例）**：公告-only 返回 None / 公告+财报选财报 / 关键词小文件接受 / size 未知兼容 / 50KB 边界 / 端到端失败语义与消息区分 / 真财报不被误伤

## 验证
- 全量 **277 passed**（268 既有 + 9 新增），ruff 无新增告警
- 端到端模拟：窗口内只有 11.1KB 公告 → 失败不下载；同日出现 212733 财报 → 正常下载财报

## 关联
- 三层修复之一（选择层）：morning-brief #62（调度层门控）+ morning-brief #61（校验层季度一致性）另行处理

Closes #62