### PR TITLE
fix(#64): 季度/临时类文档不做内容缓存 — 消除跨季度污染与命中绕过防御

### DIFF
--- a/tests/test_cache_periodic_skip.py
+++ b/tests/test_cache_periodic_skip.py
@@ -1,0 +1,108 @@
+"""
+Regression tests for #64: 季度/临时类文档不做内容缓存.
+
+现象 (2026-08-24 实测): 修复 #60/#62 后, PDD 2026Q2 第一次下载命中窗口内
+8/21 董事去世公告 (11.1KB) → 被缓存; 再次下载 Q2 **直接命中缓存返回公告**
+(绕过 #62 防御), 清缓存后才重新触发防御. 根因: 缓存 key
+md5(market:code:year:doc_type) 不含 report_period → PDD Q1/Q2/Q3 共享同一
+key → 跨季度污染 + 命中缓存绕过季度选择逻辑.
+
+修复: 季度/临时类文档 (6k/10q/quarterly/interim_report/q1_report/q3_report/
+quarterly_report/季度) 直接跳过缓存 get/put, 每次真实走季度窗口选择.
+
+这些测试只测缓存行为, 不下载真实文件.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from unified_downloader.core.downloader import UnifiedDownloader, _is_periodic_doc_type
+from unified_downloader.models.enums import Market
+from unified_downloader.models.entities import DownloadResult
+
+
+class TestIsPeriodicDocType:
+    @pytest.mark.parametrize(
+        "doc_type",
+        ["6k", "6K", "10q", "10-Q", "quarterly", "interim_report",
+         "q1_report", "q3_report", "quarterly_report", "季度"],
+    )
+    def test_periodic_types(self, doc_type):
+        assert _is_periodic_doc_type(doc_type) is True
+
+    @pytest.mark.parametrize(
+        "doc_type",
+        ["10k", "annual_report", "20f", "8k", "s1", "f1", "424b4",
+         "prospectus", None, ""],
+    )
+    def test_non_periodic_types(self, doc_type):
+        assert _is_periodic_doc_type(doc_type) is False
+
+
+class TestQuarterlySkipsCache:
+    """季度类文档: 不命中缓存, 下载后不写缓存."""
+
+    def _downloader(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        downloader = UnifiedDownloader()
+        # 真实下载返回新文件
+        fresh = tmp_path / "PDD_2024_6K_fresh.pdf"
+        fresh.write_bytes(b"%PDF-1.4\nfresh\n" + b"x" * 128)
+        ok = DownloadResult(success=True, file_path=str(fresh))
+        monkeypatch.setattr(
+            downloader._adapters[Market.M], "download", lambda **kw: ok
+        )
+        return downloader, fresh
+
+    def test_6k_does_not_hit_stale_cache(self, monkeypatch, tmp_path):
+        """#64 核心: 预置 6k 缓存条目也不命中 → 走真实下载."""
+        downloader, fresh = self._downloader(monkeypatch, tmp_path)
+
+        stale = tmp_path / "PDD_2024_6K_stale.pdf"
+        stale.write_bytes(b"%PDF-1.4\nstale 8/21 announcement\n" + b"x" * 128)
+        downloader._cache_manager.put("m", "PDD", 2024, "6k", stale)
+        stale.unlink()
+
+        result = downloader.download("PDD", 2024, "6k", market=Market.M)
+        assert result.success is True
+        assert result.cached is False
+        assert result.file_path == str(fresh)
+
+    def test_quarterly_download_does_not_write_cache(self, monkeypatch, tmp_path):
+        """#64: 下载成功后不写缓存 — 下次仍走真实选择."""
+        downloader, fresh = self._downloader(monkeypatch, tmp_path)
+
+        result = downloader.download("PDD", 2024, "6k", market=Market.M)
+        assert result.success is True
+
+        # 下载成功但缓存里无 6k 条目
+        hit = downloader._cache_manager.get("m", "PDD", 2024, "6k")
+        assert hit is None
+
+    def test_annual_doc_still_cached(self, monkeypatch, tmp_path):
+        """回归保护: 年度文档 (10k) 仍走缓存 (不受 #64 影响)."""
+        monkeypatch.chdir(tmp_path)
+        downloader = UnifiedDownloader()
+        source = tmp_path / "AAPL_2024_10K.pdf"
+        source.write_bytes(b"%PDF-1.4\nannual fixture\n" + b"x" * 128)
+        downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+        source.unlink()
+
+        result = downloader.download("AAPL", 2024, "10k", market=Market.M)
+        assert result.success is True
+        assert result.cached is True  # 年度文档缓存保留
+
+    def test_10q_skips_cache_even_when_prepopulated(self, monkeypatch, tmp_path):
+        """10q (FPI→6-K) 预置缓存也不命中 (跨季度污染防护)."""
+        downloader, fresh = self._downloader(monkeypatch, tmp_path)
+        stale = tmp_path / "PDD_2024_6K_stale.pdf"
+        stale.write_bytes(b"%PDF-1.4\nstale\n" + b"x" * 128)
+        downloader._cache_manager.put("m", "PDD", 2024, "10q", stale)
+        stale.unlink()
+
+        result = downloader.download("PDD", 2024, "10q", market=Market.M)
+        assert result.success is True
+        assert result.cached is False
+        assert result.file_path == str(fresh)

--- a/tests/test_cache_periodic_skip.py
+++ b/tests/test_cache_periodic_skip.py
@@ -26,7 +26,7 @@ from unified_downloader.models.entities import DownloadResult
 class TestIsPeriodicDocType:
     @pytest.mark.parametrize(
         "doc_type",
-        ["6k", "6K", "10q", "10-Q", "quarterly", "interim_report",
+        ["6k", "6K", "10q", "10-Q", "ten_q", "quarterly", "interim_report",
          "q1_report", "q3_report", "quarterly_report", "季度"],
     )
     def test_periodic_types(self, doc_type):
@@ -106,3 +106,64 @@ class TestQuarterlySkipsCache:
         assert result.success is True
         assert result.cached is False
         assert result.file_path == str(fresh)
+
+    def test_ten_q_alias_skips_cache(self, monkeypatch, tmp_path):
+        """#64 review defect2: ten_q 别名 (m_stock._QUARTERLY_DOC_TYPES 含) 也跳过缓存."""
+        downloader, fresh = self._downloader(monkeypatch, tmp_path)
+        stale = tmp_path / "PDD_2024_6K_stale.pdf"
+        stale.write_bytes(b"%PDF-1.4\nstale\n" + b"x" * 128)
+        downloader._cache_manager.put("m", "PDD", 2024, "ten_q", stale)
+        stale.unlink()
+
+        result = downloader.download("PDD", 2024, "ten_q", market=Market.M)
+        assert result.success is True
+        assert result.cached is False
+        assert result.file_path == str(fresh)
+
+    @pytest.mark.asyncio
+    async def test_async_6k_skips_cache(self, monkeypatch, tmp_path):
+        """#64 review defect1: async 路径季度文档也不命中缓存 (async get/put 都门控)."""
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+        downloader = AsyncUnifiedDownloader()
+
+        stale = tmp_path / "PDD_2024_6K_stale.pdf"
+        stale.write_bytes(b"%PDF-1.4\nstale async\n" + b"x" * 128)
+        downloader._downloader._cache_manager.put("m", "PDD", 2024, "6k", stale)
+        stale.unlink()
+
+        # mock async 真实下载 (async_download 是协程, 需 awaitable)
+        fresh = tmp_path / "PDD_2024_6K_fresh.pdf"
+        fresh.write_bytes(b"%PDF-1.4\nfresh async\n" + b"x" * 128)
+        ok = DownloadResult(success=True, file_path=str(fresh))
+
+        async def fake_async_download(*a, **kw):
+            return ok
+
+        monkeypatch.setattr(
+            downloader._downloader._adapters[Market.M], "async_download",
+            fake_async_download,
+        )
+
+        result = await downloader.download("PDD", 2024, "6k", market=Market.M)
+        assert result.success is True
+        assert result.cached is False
+        assert result.file_path == str(fresh)
+        await downloader.close()
+
+    @pytest.mark.asyncio
+    async def test_async_annual_still_cached(self, monkeypatch, tmp_path):
+        """回归保护: async 年度文档 (10k) 仍走缓存."""
+        monkeypatch.chdir(tmp_path)
+        from unified_downloader.core.async_downloader import AsyncUnifiedDownloader
+        downloader = AsyncUnifiedDownloader()
+
+        source = tmp_path / "AAPL_2024_10K.pdf"
+        source.write_bytes(b"%PDF-1.4\nasync annual\n" + b"x" * 128)
+        downloader._downloader._cache_manager.put("m", "AAPL", 2024, "10k", source)
+        source.unlink()
+
+        result = await downloader.download("AAPL", 2024, "10k", market=Market.M)
+        assert result.success is True
+        assert result.cached is True
+        await downloader.close()

--- a/tests/test_us_cache_semantic_filename.py
+++ b/tests/test_us_cache_semantic_filename.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from unified_downloader.core.downloader import UnifiedDownloader
+from unified_downloader.core.downloader import UnifiedDownloader, _is_periodic_doc_type
 from unified_downloader.models.enums import Market
+from unified_downloader.models.entities import DownloadResult
 
 
 def test_us_cache_hit_restores_semantic_download_filename(tmp_path, monkeypatch):
@@ -98,8 +99,13 @@ def test_us_annual_report_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
     assert result.file_path == str(Path("downloads/m/PDD/PDD_2024_20F.pdf"))
 
 
-def test_us_quarterly_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
-    """US quarterly/10q cache hits must preserve FPI 6-K semantic names."""
+def test_us_quarterly_doc_skips_cache(tmp_path, monkeypatch):
+    """#64: 季度文档 (10q→6-K) 不做内容缓存 — 即使 cache 里有条目也不命中.
+
+    之前季度文档缓存 key 不含 report_period, Q1/Q2/Q3 共享 key → 跨季度污染,
+    且命中缓存绕过季度窗口选择/防御 (错误文件被缓存后永远重试同一错误文件).
+    现在季度类文档直接跳过缓存 get/put, 每次真实走季度窗口选择.
+    """
     monkeypatch.chdir(tmp_path)
     downloader = UnifiedDownloader()
     monkeypatch.setattr(
@@ -108,16 +114,25 @@ def test_us_quarterly_cache_hit_uses_fpi_actual_form(tmp_path, monkeypatch):
         lambda code: "6-K",
     )
 
-    source = tmp_path / "PDD_2024_6K.pdf"
-    source.write_bytes(b"%PDF-1.4\nfpi quarterly cache fixture\n" + b"x" * 128)
+    # 预置一个 10q 缓存条目 (旧行为会命中并返回此 stale 文件)
+    source = tmp_path / "PDD_2024_6K_stale.pdf"
+    source.write_bytes(b"%PDF-1.4\nstale quarterly fixture\n" + b"x" * 128)
     downloader._cache_manager.put("m", "PDD", 2024, "10q", source)
     source.unlink()
+
+    # mock adapter 真实下载返回新文件
+    fresh = tmp_path / "PDD_2024_6K_fresh.pdf"
+    fresh.write_bytes(b"%PDF-1.4\nfresh quarterly\n" + b"x" * 128)
+    ok = DownloadResult(success=True, file_path=str(fresh))
+    monkeypatch.setattr(
+        downloader._adapters[Market.M], "download", lambda **kw: ok
+    )
 
     result = downloader.download("PDD", 2024, "10q", market=Market.M)
 
     assert result.success is True
-    assert result.cached is True
-    assert result.file_path == str(Path("downloads/m/PDD/PDD_2024_6K.pdf"))
+    assert result.cached is False          # 未命中缓存 (季度不缓存)
+    assert result.file_path == str(fresh)  # 走真实下载, 而非 stale 缓存
 
 
 def test_us_cache_hit_exposes_original_cache_path_metadata(tmp_path, monkeypatch):

--- a/tests/test_us_cache_semantic_filename.py
+++ b/tests/test_us_cache_semantic_filename.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from unified_downloader.core.downloader import UnifiedDownloader, _is_periodic_doc_type
+from unified_downloader.core.downloader import UnifiedDownloader
 from unified_downloader.models.enums import Market
 from unified_downloader.models.entities import DownloadResult
 

--- a/unified_downloader/core/async_downloader.py
+++ b/unified_downloader/core/async_downloader.py
@@ -14,7 +14,7 @@ from unified_downloader.models.entities import (
     TaskStatus,
 )
 from unified_downloader.models.callbacks import ProgressCallbackType
-from unified_downloader.core.downloader import UnifiedDownloader
+from unified_downloader.core.downloader import UnifiedDownloader, _is_periodic_doc_type
 from unified_downloader.core.config import Config, get_default_config
 from unified_downloader.infra import AsyncHTTPClient
 
@@ -63,13 +63,16 @@ class AsyncUnifiedDownloader:
                 use_cache=use_cache, **kwargs
             )
 
-        # 检查缓存
+        # 检查缓存 (#64 review 补 async: 季度/临时类文档不缓存 — 与 sync 一致,
+        # 否则 async API 命中缓存绕过季度窗口选择/防御)
         if market is None:
             market = self._downloader._detect_market(code)
 
-        hit = self._downloader._cache_manager.get(
-            market.value, code, year, document_type
-        )
+        hit = None
+        if not _is_periodic_doc_type(document_type):
+            hit = self._downloader._cache_manager.get(
+                market.value, code, year, document_type
+            )
         if hit:
             # W40-#49: 与同步路径一致 — 语义路径直接返回; 老条目走还原。
             # 另补齐 V4: 要 PDF 而缓存是 HTML 时不短路缓存 (sync 已有,
@@ -195,6 +198,7 @@ class AsyncUnifiedDownloader:
             if (
                 use_cache
                 and self.config.download.cache_enabled
+                and not _is_periodic_doc_type(document_type)
                 and result.file_path
             ):
                 try:

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 # 缓存又绕过 #60/#62 防御. 不做缓存 = 每次真实走季度窗口选择, 彻底消除.
 # 归一化: 小写 + 去掉连字符/下划线 (接受 "6K"/"10-Q"/"quarterly_report").
 _PERIODIC_DOC_TYPES = frozenset({
-    "6k", "10q", "quarterly", "interimreport", "q1report", "q3report",
+    "6k", "10q", "tenq", "quarterly", "interimreport", "q1report", "q3report",
     "quarterlyreport", "quarterlyq1", "quarterlyq3", "季度",
 })
 

--- a/unified_downloader/core/downloader.py
+++ b/unified_downloader/core/downloader.py
@@ -43,12 +43,36 @@ from unified_downloader.exceptions import (
 
 logger = logging.getLogger(__name__)
 
+# #64 (2026-08-24): 季度/临时类文档不做内容缓存.
+# 这些文档的内容强依赖季度选择逻辑 (窗口期从无→公告→真财报演变), 且缓存
+# key 不含 report_period → 同 code+year 下 Q1-Q4 共享 key 跨季度污染, 命中
+# 缓存又绕过 #60/#62 防御. 不做缓存 = 每次真实走季度窗口选择, 彻底消除.
+# 归一化: 小写 + 去掉连字符/下划线 (接受 "6K"/"10-Q"/"quarterly_report").
+_PERIODIC_DOC_TYPES = frozenset({
+    "6k", "10q", "quarterly", "interimreport", "q1report", "q3report",
+    "quarterlyreport", "quarterlyq1", "quarterlyq3", "季度",
+})
+
+
+def _is_periodic_doc_type(document_type: Optional[str]) -> bool:
+    """季度/临时类文档 → 不做内容缓存 (#64)."""
+    if not document_type:
+        return False
+    norm = document_type.lower().replace("-", "").replace("_", "")
+    return norm in _PERIODIC_DOC_TYPES
+
 
 class UnifiedDownloader:
     """
     统一下载器
 
     支持A股、美股、港股年报和IPO文档下载
+
+    #64 (2026-08-24): 季度/临时类文档不做内容缓存 — 缓存 key 不含 report_period,
+    PDD 2026Q1/Q2/Q3 共享同一 key (md5(m:PDD:2026:6k)) → 跨季度污染; 且命中
+    缓存发生在季度选择逻辑之前 → 错误文件 (跨季度旧财报/非财报公告) 被缓存后
+    绕过 #60/#62 防御永远重试同一错误文件. 季度财报强依赖季度窗口选择 (窗口期
+    内内容会从无→公告→真财报演变), 缓存风险 > 收益, 直接不缓存.
 
     Example:
         >>> downloader = UnifiedDownloader()
@@ -160,8 +184,13 @@ class UnifiedDownloader:
         if market is None:
             market = self._detect_market(code)
 
-        # 检查缓存
-        if use_cache and self.config.download.cache_enabled:
+        # 检查缓存 (#64: 季度/临时类文档不缓存 — 见 _PERIODIC_DOC_TYPES, 否则
+        # 命中缓存绕过季度窗口选择/防御)
+        if (
+            use_cache
+            and self.config.download.cache_enabled
+            and not _is_periodic_doc_type(document_type)
+        ):
             hit = self._cache_manager.get(
                 market.value, code, year, document_type
             )
@@ -307,10 +336,11 @@ class UnifiedDownloader:
                     source=result.source,
                 )
 
-                # 添加到缓存
+                # 添加到缓存 (#64: 季度/临时类文档不缓存 — 见 _PERIODIC_DOC_TYPES)
                 if (
                     use_cache
                     and self.config.download.cache_enabled
+                    and not _is_periodic_doc_type(document_type)
                     and result.file_path
                 ):
                     # W40-#50 P1: 缓存写失败不应把成功下载记为市场失败 —


### PR DESCRIPTION
## 问题 (#64)

修复 #60/#62 后实测 PDD 2026Q2：第一次下载命中窗口内 8/21 董事去世公告（11.1KB）→ **被缓存**；再次下载 Q2 **直接命中缓存返回公告**（完全绕过 #62 防御），清缓存后才重新触发 `NO_FILINGS_IN_QUARTER_WINDOW`。

**根因**：`infra/cache.py:105` 缓存 key = `md5(market:code:year:doc_type)`，**不含 report_period** → PDD 2026Q1/Q2/Q3 共享同一 key（`md5(m:PDD:2026:6k)`）。且命中缓存在 adapter 季度选择逻辑**之前**返回 → 错误文件（跨季度旧财报 / 非财报公告）被永久缓存后，季度窗口防御永不触发。

## 修复

**季度/临时类文档不做内容缓存**（`core/downloader.py`）：
- 新增 `_PERIODIC_DOC_TYPES` + `_is_periodic_doc_type()`：`6k / 10q / quarterly / interim_report / q1_report / q3_report / quarterly_report / 季度`（含 `10-Q`/`6K` 等连字符/大小写变体）
- 缓存 **get 与 put 都跳过**这类文档 → 每次真实走季度窗口选择（窗口期内内容会从"无→公告→真财报"演变，缓存风险 > 收益）
- 年度文档（10k / 20f / annual / s1 等）缓存**保留**，不受影响

**为什么不用"key 加 report_period"**：那只解决跨季度污染；解决不了"同季度错误文件被缓存后命中绕过防御"（issue 复现步骤 2 正是这个场景）。直接不缓存最彻底。

## 测试
- 新增 `tests/test_cache_periodic_skip.py`（10 用例）：`6k/10q/quarterly` 预置缓存也不命中、下载后不写缓存、年度文档缓存回归保护
- 改 `test_us_cache_semantic_filename.py` 季度用例：从"缓存命中"改为"季度不缓存走真实下载"
- 全量 **302 passed**，ruff 无告警

Closes #64