### PR TITLE
fix(#66): 财年制公司 6-K 期别窗口 — BABA/NVDA/AAPL 按财年解析 report_period

### DIFF
--- a/tests/test_6k_window_cross_year.py
+++ b/tests/test_6k_window_cross_year.py
@@ -113,7 +113,8 @@ class TestQ4CrossYear:
         """_download_form 对 Q4/FY/H2 的 6-K 搜索要放行次年 filing"""
         captured = {}
 
-        def fake_search(ticker, form_type, year, size=10, include_next_year=False):
+        def fake_search(ticker, form_type, year, size=10, include_next_year=False,
+                        **kwargs):  # prev_year_floor (#66)
             captured["include_next_year"] = include_next_year
             return [_mk_filing("Q4", 400000, "2026-02-10")]
 
@@ -130,7 +131,8 @@ class TestQ4CrossYear:
     def test_download_form_no_flag_for_q2(self, adapter):
         captured = {}
 
-        def fake_search(ticker, form_type, year, size=10, include_next_year=False):
+        def fake_search(ticker, form_type, year, size=10, include_next_year=False,
+                        **kwargs):  # prev_year_floor (#66)
             captured["include_next_year"] = include_next_year
             return [_mk_filing("Q2", 200000, "2025-08-13")]
 
@@ -147,7 +149,8 @@ class TestQ4CrossYear:
     def test_download_form_no_flag_without_report_period(self, adapter):
         captured = {}
 
-        def fake_search(ticker, form_type, year, size=10, include_next_year=False):
+        def fake_search(ticker, form_type, year, size=10, include_next_year=False,
+                        **kwargs):  # prev_year_floor (#66)
             captured["include_next_year"] = include_next_year
             return [_mk_filing("X", 1000, "2025-05-01")]
 

--- a/tests/test_m_stock_fiscal_period_window.py
+++ b/tests/test_m_stock_fiscal_period_window.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for 财年制公司 6-K 期别窗口 (#66, 2026-08-30).
+
+Regression: BABA 是财年制公司 (财年 3 月底结束), "2027Q1" = 财年 2027 的
+Q1 = 日历 2026年4-6月季度 (June Quarter 2026, 8/20 发布). 之前
+_report_period_target_end 一律按自然年映射 → 目标期算成 2027-03-31 →
+窗口 2027-04-14~06-24 错位一年 → 8/20 真财报完全落在窗口外, 永远选不到.
+
+修复:
+1. _FISCAL_YEAR_END_MONTH 财年末月份映射 (BABA=3 / NVDA=1 / AAPL=9),
+   fiscal_end_month 给定时按财年解析目标期; =12 或未列公司退化回自然年.
+2. 搜索层 prev_year_floor: 财年制公司标签年 > 发布年 (BABA "2027Q1"
+   发布于 2026-08), 搜索要放开上一年, 下界收到目标期结束日.
+
+这些测试只测选择/窗口逻辑, 不下载真实文件.
+"""
+import datetime
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import (  # noqa: E402
+    MStockAdapter,
+    _quarter_window,
+    _quarter_window_missed,
+    _report_period_target_end,
+    fiscal_year_end_month,
+)
+
+
+def _mk_filing(accession: str, size: int, filed_at: str, exhibits=None):
+    """构造一条 filing dict（模拟 _search_edgar 返回）。"""
+    return {
+        "ticker": "BABA",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "1577552",
+        "companyName": accession,
+        "linkToTxt": f"https://example.com/{accession}/index.html",
+        "linkToHtml": f"https://example.com/{accession}/index.html",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits or [],
+    }
+
+
+# BABA 真实 6-K 场景 (2026-08-30 issue #66): 8/20 "June Quarter 2026"
+# 真财报 463KB 在列, 但按自然年窗口 (2027-04~06) 永远选不到
+_BABA_2026_FILINGS = [
+    _mk_filing("BABA-Q1FY27", 463000, "2026-08-20",
+               exhibits=[{"url": "https://x/baba_ex99.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm26_ex99-1.htm"}]),
+    _mk_filing("BABA-PR-JUL", 17272, "2026-07-06",
+               exhibits=[{"url": "https://x/pr.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm25_ex99-1.htm"}]),
+    _mk_filing("BABA-Q4FY26", 215461, "2026-05-14",
+               exhibits=[{"url": "https://x/q4.htm",
+                          "description": "EXHIBIT 99.1",
+                          "document": "tm24_ex99-1.htm"}]),
+]
+
+
+class TestFiscalTargetEnd:
+    """财年制 report_period → 目标报告期结束日"""
+
+    def test_baba_fy_march(self):
+        # BABA 财年 2027 止 2027-03-31; Q1 止 2026-06-30 (June Quarter 2026)
+        assert _report_period_target_end("2027Q1", 3) == datetime.date(2026, 6, 30)
+        assert _report_period_target_end("2027Q2", 3) == datetime.date(2026, 9, 30)
+        assert _report_period_target_end("2027Q3", 3) == datetime.date(2026, 12, 31)
+        assert _report_period_target_end("2027Q4", 3) == datetime.date(2027, 3, 31)
+        assert _report_period_target_end("2027FY", 3) == datetime.date(2027, 3, 31)
+        assert _report_period_target_end("2027H1", 3) == datetime.date(2026, 9, 30)
+        assert _report_period_target_end("2027H2", 3) == datetime.date(2027, 3, 31)
+
+    def test_nvda_fy_january(self):
+        # NVDA 财年止 1 月底: FY2026 Q4 → 2026-01; FY2027 Q1 → 2026-04
+        assert _report_period_target_end("2026Q4", 1) == datetime.date(2026, 1, 31)
+        assert _report_period_target_end("2027Q1", 1) == datetime.date(2026, 4, 30)
+
+    def test_aapl_fy_september(self):
+        # AAPL 财年止 9 月底: FY2026 Q4 → 2026-09; FY2026 Q1 → 2025-12
+        assert _report_period_target_end("2026Q4", 9) == datetime.date(2026, 9, 30)
+        assert _report_period_target_end("2026Q1", 9) == datetime.date(2025, 12, 31)
+
+    def test_no_fiscal_month_keeps_calendar_behavior(self):
+        """未列公司 / 不传 fiscal_end_month → 自然年映射 (旧行为不变)."""
+        assert _report_period_target_end("2027Q1") == datetime.date(2027, 3, 31)
+        assert _report_period_target_end("2027Q1", None) == datetime.date(2027, 3, 31)
+        assert _report_period_target_end("2026Q2", 12) == datetime.date(2026, 6, 30)
+
+    def test_invalid_period_returns_none(self):
+        assert _report_period_target_end("2027H3", 3) is None
+        assert _report_period_target_end("garbage", 3) is None
+        assert _report_period_target_end(None, 3) is None
+
+    def test_fiscal_year_end_month_lookup(self):
+        assert fiscal_year_end_month("BABA") == 3
+        assert fiscal_year_end_month("baba") == 3
+        assert fiscal_year_end_month("NVDA") == 1
+        assert fiscal_year_end_month("AAPL") == 9
+        assert fiscal_year_end_month("PDD") is None
+        assert fiscal_year_end_month("") is None
+        assert fiscal_year_end_month(None) is None
+
+
+class TestFiscalQuarterWindow:
+    """财年制窗口: BABA 2027Q1 → 2026-07-14 ~ 2026-09-23, 8/20 真财报在列"""
+
+    def test_baba_2027q1_window_contains_aug20_filing(self):
+        window = _quarter_window("2027Q1", 3)
+        assert window is not None
+        lo, hi = window
+        assert lo == datetime.date(2026, 7, 14)
+        assert hi == datetime.date(2026, 9, 23)
+        assert lo <= datetime.date(2026, 8, 20) <= hi
+
+    def test_window_missed_detects_before_fix_would_miss(self):
+        """修复前 (自然年) 窗口内无 filing → missed=True; 修复后命中."""
+        assert _quarter_window_missed(
+            _BABA_2026_FILINGS, "2027Q1") is True  # 自然年窗口 (错位)
+        assert _quarter_window_missed(
+            _BABA_2026_FILINGS, "2027Q1", 3) is False  # 财年窗口命中 8/20
+
+    def test_pick_earnings_6k_baba_fiscal(self, ):
+        adapter = MStockAdapter(MagicMock(), [])
+        picked = adapter._pick_earnings_6k(
+            _BABA_2026_FILINGS, report_period="2027Q1", fiscal_end_month=3)
+        assert picked is not None
+        assert picked["accessionNo"] == "BABA-Q1FY27"
+
+    def test_pick_earnings_6k_without_fiscal_returns_none(self):
+        """不传 fiscal_end_month → 自然年窗口内无 filing → None (复现 #66)."""
+        adapter = MStockAdapter(MagicMock(), [])
+        picked = adapter._pick_earnings_6k(
+            _BABA_2026_FILINGS, report_period="2027Q1")
+        assert picked is None
+
+
+class TestDownloadFormFiscalThreading:
+    """_download_form 把财年映射 / prev_year_floor 传给搜索与窗口层"""
+
+    def _run_download_form(self, adapter, code, year, report_period):
+        captured = {}
+
+        def fake_search(ticker, form_type, yr, size=10,
+                        include_next_year=False, prev_year_floor=None):
+            captured["prev_year_floor"] = prev_year_floor
+            return _BABA_2026_FILINGS
+
+        ok_result = MagicMock()
+        ok_result.success = True
+        with patch.object(adapter, "_search_filings", side_effect=fake_search), \
+             patch.object(adapter, "_download_filing", return_value=ok_result):
+            result = adapter._download_form(
+                code, "6-K", year, None, None, report_period=report_period
+            )
+        return result, captured
+
+    def test_baba_prev_year_floor_set(self):
+        """BABA 2027Q1 (year=2027): 目标期 2026-06-30 在上一年 → prev_year_floor."""
+        adapter = MStockAdapter(MagicMock(), [])
+        result, captured = self._run_download_form(
+            adapter, "BABA", 2027, "2027Q1")
+        assert result.success
+        assert captured["prev_year_floor"] == datetime.date(2026, 6, 30)
+
+    def test_calendar_filer_no_prev_year_floor(self):
+        """PDD (自然年制): 不放行上一年搜索."""
+        adapter = MStockAdapter(MagicMock(), [])
+        result, captured = self._run_download_form(
+            adapter, "PDD", 2026, "2026Q2")
+        assert result.success
+        assert captured["prev_year_floor"] is None
+
+    def test_baba_q4_same_year_no_prev_year_floor(self):
+        """BABA 2027Q4 目标期 2027-03-31 与标签同年 → 无需放开上一年."""
+        adapter = MStockAdapter(MagicMock(), [])
+        captured = {}
+
+        def fake_search(ticker, form_type, yr, size=10,
+                        include_next_year=False, prev_year_floor=None):
+            captured["prev_year_floor"] = prev_year_floor
+            # 财年 Q4 窗口 2027-04-14~06-24 内的 filing
+            return [_mk_filing("BABA-Q4FY27", 300000, "2027-05-10")]
+
+        ok_result = MagicMock()
+        ok_result.success = True
+        with patch.object(adapter, "_search_filings", side_effect=fake_search), \
+             patch.object(adapter, "_download_filing", return_value=ok_result):
+            result = adapter._download_form(
+                "BABA", "6-K", 2027, None, None, report_period="2027Q4")
+        assert result.success
+        assert captured["prev_year_floor"] is None
+
+    def test_baba_fiscal_window_picks_real_earnings(self):
+        """端到端: BABA 2027Q1 搜索结果含 8/20 真财报 → 选中它下载."""
+        adapter = MStockAdapter(MagicMock(), [])
+        picked = {}
+
+        def fake_search(ticker, form_type, yr, size=10,
+                        include_next_year=False, prev_year_floor=None):
+            return _BABA_2026_FILINGS
+
+        def fake_download(filing, ticker, form_type, year, on_progress, checkpoint):
+            picked["accessionNo"] = filing["accessionNo"]
+            ok = MagicMock()
+            ok.success = True
+            return ok
+
+        with patch.object(adapter, "_search_filings", side_effect=fake_search), \
+             patch.object(adapter, "_download_filing", side_effect=fake_download):
+            adapter._download_form("BABA", "6-K", 2027, None, None,
+                                   report_period="2027Q1")
+        assert picked["accessionNo"] == "BABA-Q1FY27"

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -27,12 +27,37 @@ from unified_downloader.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-def _report_period_target_end(report_period):
+# #66 (2026-08-30): 财年制公司财年末月份映射. report_period 是 Longbridge
+# 财年制标签 (BABA "2027Q1" = 财年 2027 的 Q1 = 日历 2026年4-6月季度, 8/20
+# 发布), 财年末月 ≠ 12 的公司按自然年映射会把目标期错位一年 (8/20 真财报
+# 落在 2027 年窗口外, 选不到). 仅列已确认的财年制公司; 财年止 12 月
+# (含多数中概股) 与未列公司维持自然年映射.
+_FISCAL_YEAR_END_MONTH: Dict[str, int] = {
+    "BABA": 3,  # 阿里巴巴 财年止 3 月底
+    "NVDA": 1,  # 英伟达 财年止 1 月底 (FY2026 = 2025-02 ~ 2026-01)
+    "AAPL": 9,  # 苹果 财年止 9 月底
+}
+
+
+def fiscal_year_end_month(ticker: Optional[str]) -> Optional[int]:
+    """ticker → 财年末月份 (1-12); 非财年制 / 未知公司返回 None (#66)."""
+    if not ticker:
+        return None
+    return _FISCAL_YEAR_END_MONTH.get(str(ticker).upper().strip())
+
+
+def _report_period_target_end(report_period, fiscal_end_month=None):
     """report_period ('2026Q2'/'2026H1'/'2026FY') → 目标报告期结束日.
 
     W40-#50: 之前 H1/H2 半年报按 Q1/Q2 映射 month_end (H1→3-31, H2→6-30),
     窗口错一个季度 — RACE 等公司 7 月底发布的中报完全落在窗口外;
     H3/H4 无意义, 返回 None.
+
+    #66: 财年制公司 (fiscal_end_month 给定, 如 BABA=3) 按财年解析 —
+    财年 y 止于 y 年 fiscal_end_month 月底, Qk 距财年末 (Q4) 3*(4-k) 个月:
+    BABA 2027Q1 → 财年 2027 (止 2027-03-31) 的 Q1 → 2026-06-30,
+    而非自然年映射的 2027-03-31 (错位一年). fiscal_end_month=12 时公式
+    退化为自然年映射, 与旧行为一致.
     """
     if not report_period:
         return None
@@ -43,6 +68,21 @@ def _report_period_target_end(report_period):
             return None
         y = int(m.group(1))
         kind, idx = m.group(2), m.group(3)
+        if fiscal_end_month:
+            if not idx:  # FY → 财年末本身
+                month_end = fiscal_end_month
+            elif kind == "H":
+                if idx not in ("1", "2"):
+                    return None
+                month_end = fiscal_end_month - (6 if idx == "1" else 0)
+            else:
+                month_end = fiscal_end_month - 3 * (4 - int(idx))
+            yy = y
+            while month_end <= 0:
+                month_end += 12
+                yy -= 1
+            last_day = calendar.monthrange(yy, month_end)[1]
+            return datetime.date(yy, month_end, last_day)
         if not idx:
             return datetime.date(y, 12, 31)  # FY 无明确季度 → 12-31
         if kind == "H":
@@ -83,9 +123,15 @@ def _filing_filed_date(f: Dict[str, Any]) -> Optional[datetime.date]:
         return None
 
 
-def _quarter_window(report_period: Optional[str]) -> Optional[Tuple[datetime.date, datetime.date]]:
-    """report_period → 目标季度窗口 (window_lo, window_hi); 无法解析返回 None."""
-    target_end = _report_period_target_end(report_period)
+def _quarter_window(
+    report_period: Optional[str],
+    fiscal_end_month: Optional[int] = None,
+) -> Optional[Tuple[datetime.date, datetime.date]]:
+    """report_period → 目标季度窗口 (window_lo, window_hi); 无法解析返回 None.
+
+    #66: 财年制公司传 fiscal_end_month 按财年解析目标期.
+    """
+    target_end = _report_period_target_end(report_period, fiscal_end_month)
     if target_end is None:
         return None
     lo = target_end + datetime.timedelta(days=QUARTER_EARLY_DAYS)
@@ -94,14 +140,16 @@ def _quarter_window(report_period: Optional[str]) -> Optional[Tuple[datetime.dat
 
 
 def _quarter_window_missed(
-    filings: List[Dict[str, Any]], report_period: Optional[str]
+    filings: List[Dict[str, Any]],
+    report_period: Optional[str],
+    fiscal_end_month: Optional[int] = None,
 ) -> bool:
     """目标报告期有可解析窗口, 但 filings 里没有一条落在窗口内.
 
     #60 修复: 命中表示目标季度财报未发布 / 搜索缓存未收录 — 调用方应明确失败,
     绝不能回退按 size 选别的季度财报 (PDD 2026Q2 下成 2025Q4 3/26 的根因).
     """
-    window = _quarter_window(report_period)
+    window = _quarter_window(report_period, fiscal_end_month)
     if window is None:
         return False
     lo, hi = window
@@ -329,6 +377,7 @@ class MStockAdapter(BaseStockAdapter):
         year: Optional[int],
         size: int = 10,
         include_next_year: bool = False,
+        prev_year_floor: Optional[datetime.date] = None,
     ) -> List[Dict[str, Any]]:
         """
         使用edgartools搜索SEC filings
@@ -366,12 +415,23 @@ class MStockAdapter(BaseStockAdapter):
                         # size 截断, 只放宽年份会让次年后半年淹没结果 —
                         # 上界收到次年 6-30, 恰好覆盖发布窗口
                         allowed = {year, year + 1} if include_next_year else {year}
+                        # #66: 财年制公司目标期在标签年的上一年 (BABA "2027Q1"
+                        # 发布于 2026-08), 放开上一年; 下界收到目标期结束日 —
+                        # 财报不可能发布于报告期结束之前
+                        if prev_year_floor is not None:
+                            allowed.add(year - 1)
                         if filing_year not in allowed:
                             continue
                         if (
                             include_next_year
                             and filing_year == year + 1
                             and filing.filing_date.month > 6
+                        ):
+                            continue
+                        if (
+                            prev_year_floor is not None
+                            and filing_year == year - 1
+                            and filing.filing_date < prev_year_floor
                         ):
                             continue
                     except (ValueError, IndexError):
@@ -448,6 +508,7 @@ class MStockAdapter(BaseStockAdapter):
         year: Optional[int],
         size: int = 10,
         include_next_year: bool = False,
+        prev_year_floor: Optional[datetime.date] = None,
     ) -> List[Dict[str, Any]]:
         """
         使用sec-api搜索SEC filings
@@ -469,7 +530,11 @@ class MStockAdapter(BaseStockAdapter):
         if form_type:
             parts.append(f'formType:"{form_type}"')
         if year:
-            date_from = f"{year}-01-01"
+            # #66: 财年制公司目标期在标签年的上一年, date_from 下探到目标期
+            # 结束日 (财报不可能发布于报告期结束之前)
+            date_from = (
+                prev_year_floor.isoformat() if prev_year_floor else f"{year}-01-01"
+            )
             # W40-#50: Q4/FY 窗口跨年 — 扩到次年但上界收 6-30 (与新→旧
             # 返回 + size 截断的 edgar 行为对齐, 防次年后半年淹没窗口)
             if include_next_year:
@@ -512,6 +577,7 @@ class MStockAdapter(BaseStockAdapter):
         year: Optional[int],
         size: int = 10,
         include_next_year: bool = False,
+        prev_year_floor: Optional[datetime.date] = None,
     ) -> List[Dict[str, Any]]:
         """
         搜索SEC filings (优先edgartools，失败则sec-api)
@@ -541,6 +607,7 @@ class MStockAdapter(BaseStockAdapter):
                     results = self._search_edgar(
                         ticker, form_type, year, size,
                         include_next_year=include_next_year,
+                        prev_year_floor=prev_year_floor,
                     )
                     _dt_edgar = time.monotonic() - _t_edgar
                     logger.info(
@@ -566,6 +633,7 @@ class MStockAdapter(BaseStockAdapter):
                     return self._search_sec_api(
                         ticker, form_type, year, size,
                         include_next_year=include_next_year,
+                        prev_year_floor=prev_year_floor,
                     )
                 except Exception as e:
                     last_error = e
@@ -632,6 +700,10 @@ class MStockAdapter(BaseStockAdapter):
             )
 
         try:
+            # #66: 财年制公司 (BABA/NVDA/AAPL...) 按财年解析目标期与窗口 —
+            # report_period 是 Longbridge 财年制标签, 自然年映射对财年末月
+            # ≠ 12 的公司整体错位一年 (BABA 2027Q1 = 2026年4-6月季度)
+            fiscal_end_month = fiscal_year_end_month(ticker)
             # W39 8-9 RACE 修复: 6-K 是"封面+exhibit"结构, 同一公司一年有几十条 6-K
             # (普通 PR / 董事会变动 / 财报). 若只取 size=1 (最新一条), 可能取到普通 PR
             # (如 RACE 7-31 fnvbb310726prex.htm 3KB), 而非 Q2 财报 (7-30 interim report
@@ -639,32 +711,53 @@ class MStockAdapter(BaseStockAdapter):
             size = 10 if form_type == "6-K" else 1
             # W40-#50: Q4/FY/H2 的财报窗口落在次年 1~3 月 — 搜索层要允许
             # 次年 filing, 否则窗口逻辑永远空转、回退 size 启发式选错文档
-            _target_end = _report_period_target_end(report_period)
+            _target_end = _report_period_target_end(report_period, fiscal_end_month)
             include_next_year = bool(
                 form_type == "6-K"
                 and year is not None
                 and _target_end is not None
                 and _target_end.month == 12
             )
+            # #66: 财年制公司标签年可能大于发布年 (BABA "2027Q1" 发布于
+            # 2026-08) — 搜索层放开上一年, 下界收到目标期结束日, 否则窗口
+            # 命中的 filing 根本不在搜索结果里 (W40-#50 include_next_year
+            # 的镜像场景)
+            prev_year_floor = (
+                _target_end
+                if form_type == "6-K"
+                and year is not None
+                and _target_end is not None
+                and _target_end.year < year
+                else None
+            )
             filings = self._search_filings(
                 ticker, form_type, year, size=size,
                 include_next_year=include_next_year,
+                prev_year_floor=prev_year_floor,
             )
 
             if not filings:
                 return _try_ir_fallback()
 
             filing = filings[0]
-            if form_type == "6-K" and _quarter_window(report_period) is not None:
+            if (
+                form_type == "6-K"
+                and _quarter_window(report_period, fiscal_end_month) is not None
+            ):
                 # #60/#62: report_period 可解析出目标季度窗口时, 6-K 选择全权交给
                 # _pick_earnings_6k (含单条 filing). 返回 None = 窗口内无 filing
                 # (#60: 财报未发布/缓存未收录, 旧逻辑回退 max(size) 跨季度错选,
                 # PDD 2026Q2 下成 2025Q4 3/26) 或窗口内只有非财报公告 (#62: 全
                 # 0 分且 size 低于财报下限, PDD 8/21 董事去世公告 11.1KB) →
                 # 明确失败等真财报, 绝不回退跨季度 size 最大, 也不下载公告.
-                picked = self._pick_earnings_6k(filings, report_period=report_period)
+                picked = self._pick_earnings_6k(
+                    filings, report_period=report_period,
+                    fiscal_end_month=fiscal_end_month,
+                )
                 if picked is None:
-                    if _quarter_window_missed(filings, report_period):
+                    if _quarter_window_missed(
+                        filings, report_period, fiscal_end_month
+                    ):
                         detail = "窗口内无 filing, 财报可能未发布或搜索缓存未收录"
                     else:
                         detail = (
@@ -682,7 +775,10 @@ class MStockAdapter(BaseStockAdapter):
                 filing = picked
             elif form_type == "6-K" and len(filings) > 1:
                 # 无 report_period (或无法解析) → 旧逻辑: 打分优先, NVO size 回退.
-                picked = self._pick_earnings_6k(filings, report_period=report_period)
+                picked = self._pick_earnings_6k(
+                    filings, report_period=report_period,
+                    fiscal_end_month=fiscal_end_month,
+                )
                 if picked is not None:
                     filing = picked
                 else:
@@ -744,6 +840,7 @@ class MStockAdapter(BaseStockAdapter):
         self,
         filings: List[Dict[str, Any]],
         report_period: Optional[str] = None,
+        fiscal_end_month: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
         """从多条 6-K 中选财报特征最强的.
 
@@ -778,8 +875,9 @@ class MStockAdapter(BaseStockAdapter):
         # 目标季度窗口 (季度结束后第 N~M 天发布财报): 常量提到模块级
         # (QUARTER_EARLY_DAYS / QUARTER_LATE_DAYS), _download_form 也要用.
         # 解析 report_period → 目标报告期结束日 (W40-#50: 抽出共用 helper,
-        # 同步修复 H1/H2 按季度映射错一个季度的 bug)
-        target_end = _report_period_target_end(report_period)
+        # 同步修复 H1/H2 按季度映射错一个季度的 bug; #66: 财年制公司按
+        # fiscal_end_month 财年解析)
+        target_end = _report_period_target_end(report_period, fiscal_end_month)
 
         def _exhibit_score(f: Dict[str, Any]) -> int:
             """计算 filing 的 exhibit 财报特征分 (旧逻辑)."""


### PR DESCRIPTION
Fixes #66

## 改动
- `_FISCAL_YEAR_END_MONTH` 财年末映射 (BABA=3 / NVDA=1 / AAPL=9)，`_report_period_target_end` 按财年解析目标期；未列公司/12月止退化回自然年（旧行为不变）
- `_quarter_window` / `_quarter_window_missed` / `_pick_earnings_6k` 透传 `fiscal_end_month`
- 搜索层 `prev_year_floor`：财年制公司标签年 > 发布年（BABA 2027Q1 发布于 2026-08），放开上一年搜索、下界收到目标期结束日

## 修复效果
BABA 2027Q1 目标期 2027-03-31 → **2026-06-30**，窗口 2027-04-14~06-24 → **2026-07-14~09-23**，8/20 真财报（June Quarter 2026, 463KB）在列可选中。

## 测试
- 新增 `tests/test_m_stock_fiscal_period_window.py`（13 个用例：财年映射/窗口/选中/搜索层透传）
- 全量 `pytest tests/` 320 passed