### PR TITLE
fix(#68): 窗口内多条大 6-K 元数据全 0 分时按内容嗅探选择 - BABA 月度申报不再挤掉真财报

### DIFF
--- a/tests/test_m_stock_content_sniff.py
+++ b/tests/test_m_stock_content_sniff.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for 6-K 内容嗅探选择 (#68, 2026-08-30).
+
+Regression: #66 修复后 BABA 2027Q1 财年窗口正确命中 2026-07-14~09-23
+(含 8/20 真财报), 但窗口内 10 条 filing 的 exhibit 元数据全是通用描述
+("EXHIBIT 99.1") -> _exhibit_score 全 0 分 -> "size 最大" 回退选中 8/6 的
+月度股份申报 (Monthly Return, 1.24MB) - 它比真财报 (8/20, 481KB) 还大,
+MIN_EARNINGS_FILING_SIZE (50KB) 拦不住大号非财报申报.
+
+修复: 窗口内 ≥ 下限候选多条且元数据全 0 分时, _pick_by_content_sniff 拉
+各候选 exhibit 头部内容做 _EARNINGS_KEYWORDS 计数, 密度最高者胜出
+(实测 8/20 真财报 92 次, 月度申报 0 次). 全部拉取失败退回 size 最大.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# 强制导入稳定版本
+sys.path.insert(0, str(Path(__file__).parent.parent / "unified_downloader"))
+from adapters.m_stock import MStockAdapter  # noqa: E402
+
+
+def _mk_filing(accession: str, size: int, filed_at: str, exhibits=None):
+    """构造一条 filing dict（模拟 _search_edgar 返回, 通用 EXHIBIT 99.1）."""
+    return {
+        "ticker": "BABA",
+        "formType": "6-K",
+        "filedAt": filed_at,
+        "accessionNo": accession,
+        "cik": "1577552",
+        "companyName": accession,
+        "linkToTxt": f"https://example.com/{accession}/index.html",
+        "linkToHtml": f"https://example.com/{accession}/index.html",
+        "source": "edgar",
+        "size": size,
+        "_exhibits": exhibits if exhibits is not None else [
+            {"url": f"https://example.com/{accession}/ex99-1.htm",
+             "description": "EXHIBIT 99.1",
+             "document": f"{accession}_ex99-1.htm"}],
+    }
+
+
+class _FakeResp:
+    def __init__(self, content: bytes, status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+
+_EARNINGS_TEXT = (
+    "Total revenue was RMB 247,652 million for the quarter ended June 30, "
+    "2026. Net income was RMB 24,932 million and operating income grew. "
+    "Diluted earnings per share were RMB 10.41. "
+) * 20
+
+_MONTHLY_RETURN_TEXT = (
+    "Monthly Return with The Stock Exchange of Hong Kong Limited in "
+    "relation to the movements in the issuer's issued shares for July 2026. "
+) * 20
+
+
+class TestContentSniff:
+    """#68: 窗口内多条大 filing 元数据全 0 分时按内容关键词密度选择"""
+
+    @pytest.fixture
+    def adapter(self):
+        adapter = MStockAdapter(MagicMock(), [])
+        adapter._sec_user_agent = "test-agent@example.com"
+        return adapter
+
+    def test_sniff_picks_real_earnings_over_bigger_monthly_return(self, adapter):
+        """BABA 场景: 1.24MB 月度申报 vs 481KB 真财报 -> 内容密度胜出."""
+        filings = [
+            _mk_filing("BABA-MONTHLY", 1244217, "2026-08-06"),
+            _mk_filing("BABA-REAL", 481124, "2026-08-20"),
+        ]
+        urls = {
+            "https://example.com/BABA-MONTHLY/ex99-1.htm": _FakeResp(
+                _MONTHLY_RETURN_TEXT.encode()),
+            "https://example.com/BABA-REAL/ex99-1.htm": _FakeResp(
+                _EARNINGS_TEXT.encode()),
+        }
+        adapter._http_client = MagicMock()
+        adapter._http_client.get.side_effect = lambda url, headers=None: urls[url]
+
+        picked = adapter._pick_earnings_6k(
+            filings, report_period="2027Q1", fiscal_end_month=3)
+        assert picked is not None
+        assert picked["accessionNo"] == "BABA-REAL"
+
+    def test_sniff_all_fetch_fail_falls_back_to_size_max(self, adapter):
+        """全部拉取失败 -> 退回 size 最大 (旧行为, fail-open)."""
+        filings = [
+            _mk_filing("BABA-MONTHLY", 1244217, "2026-08-06"),
+            _mk_filing("BABA-REAL", 481124, "2026-08-20"),
+        ]
+        adapter._http_client = MagicMock()
+        adapter._http_client.get.side_effect = ConnectionError("network down")
+
+        picked = adapter._pick_earnings_6k(
+            filings, report_period="2027Q1", fiscal_end_month=3)
+        assert picked is not None
+        # 退回 size 最大 (旧行为)
+        assert picked["accessionNo"] == "BABA-MONTHLY"
+
+    def test_single_candidate_skips_sniff(self, adapter):
+        """窗口内只有一条大候选 -> 不嗅探, 直接 size 最大."""
+        filings = [_mk_filing("BABA-ONLY", 481124, "2026-08-20")]
+        adapter._http_client = MagicMock()
+        adapter._http_client.get.side_effect = AssertionError("不应发起嗅探请求")
+
+        picked = adapter._pick_earnings_6k(
+            filings, report_period="2027Q1", fiscal_end_month=3)
+        assert picked is not None
+        assert picked["accessionNo"] == "BABA-ONLY"
+
+    def test_non_200_response_scores_zero(self, adapter):
+        """403/404 响应计 0 分 -> 退回 size 最大."""
+        filings = [
+            _mk_filing("BABA-MONTHLY", 1244217, "2026-08-06"),
+            _mk_filing("BABA-REAL", 481124, "2026-08-20"),
+        ]
+        adapter._http_client = MagicMock()
+        adapter._http_client.get.return_value = _FakeResp(b"", status_code=403)
+
+        picked = adapter._pick_earnings_6k(
+            filings, report_period="2027Q1", fiscal_end_month=3)
+        assert picked is not None
+        assert picked["accessionNo"] == "BABA-MONTHLY"
+
+    def test_sniff_bounded_to_top_candidates(self, adapter):
+        """候选多于 CONTENT_SNIFF_MAX_CANDIDATES 时只嗅探 size top-N."""
+        from adapters.m_stock import CONTENT_SNIFF_MAX_CANDIDATES
+        filings = [
+            _mk_filing(f"FILING-{i}", 100_000 + i, f"2026-08-{i+10:02d}")
+            for i in range(CONTENT_SNIFF_MAX_CANDIDATES + 3)
+        ]
+        # 全部塞真财报文本 -> 若只嗅探 top-N, 请求次数应 ≤ N
+        adapter._http_client = MagicMock()
+        adapter._http_client.get.return_value = _FakeResp(
+            _EARNINGS_TEXT.encode())
+
+        picked = adapter._pick_earnings_6k(
+            filings, report_period="2027Q1", fiscal_end_month=3)
+        assert picked is not None
+        assert adapter._http_client.get.call_count <= CONTENT_SNIFF_MAX_CANDIDATES

--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -111,6 +111,14 @@ QUARTER_LATE_DAYS = 85  # 最晚在 ~85 天内 (跨季末但未到下一季末)
 # 此值 = 窗口内只有非财报公告 → 不下载 (返回 None 由调用方明确失败).
 MIN_EARNINGS_FILING_SIZE = 50_000
 
+# #68: 内容嗅探参数 - 窗口内多条大 filing 且 exhibit 元数据全 0 分时的
+# 兜底分档. BABA 2027Q1 实测: 8/6 月度股份申报 1.24MB 比真财报 (8/20,
+# 481KB) 还大, size 启发式失效 -> 拉候选 exhibit 头部内容按
+# _EARNINGS_KEYWORDS 计数, 密度最高者胜出 (实测 revenue×48 vs 0).
+CONTENT_SNIFF_MAX_CANDIDATES = 5   # 最多嗅探 size 最高的几条
+CONTENT_SNIFF_MAX_BYTES = 200_000  # 每条 exhibit 只读头部 (关键词密度足够)
+CONTENT_SNIFF_MAX_EXHIBITS = 2     # 每条 filing 最多嗅探前几个 exhibit
+
 
 def _filing_filed_date(f: Dict[str, Any]) -> Optional[datetime.date]:
     """filing dict → filedAt 日期 (兼容 str / date)."""
@@ -946,6 +954,19 @@ class MStockAdapter(BaseStockAdapter):
                             f"返回 None 等可证数据 (edgar 恢复/财报入库)"
                         )
                     return None
+                # #68: 窗口内多条 ≥ 下限的候选且元数据全 0 分 (描述全是通用
+                # "EXHIBIT 99.1") 时, "size 最大" 会误选大号非财报申报 -
+                # BABA 实测 8/6 月度股份申报 1.24MB 比真财报 481KB 还大.
+                # 拉各候选 exhibit 头部内容做财报关键词计数, 密度最高者胜出;
+                # 全部拉取失败退回 size 最大 (旧行为).
+                big_candidates = [
+                    f for f in in_window
+                    if int(f.get("size") or 0) >= MIN_EARNINGS_FILING_SIZE
+                ]
+                if len(big_candidates) > 1:
+                    sniffed = self._pick_by_content_sniff(big_candidates)
+                    if sniffed is not None:
+                        return sniffed
                 logger.info(
                     f"[m_stock] 6-K 窗口内无 exhibit 财报分, 选 size 最大: "
                     f"{best_in.get('accessionNo')} size={best_in.get('size')}"
@@ -974,6 +995,67 @@ class MStockAdapter(BaseStockAdapter):
                 best_score = score
                 best = filing
         return best if best_score > 0 else None
+
+    def _pick_by_content_sniff(
+        self, filings: List[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """(#68) 窗口内多条大 filing 且 exhibit 元数据全 0 分时, 按内容选.
+
+        BABA 2027Q1 实测: 8/6 月度股份申报 (Monthly Return) 1.24MB 比真财报
+        (8/20, 481KB) 还大, "size 最大" 启发式误选; 内容计数则一目了然
+        (真财报 exhibit 头部 revenue×48 / net income×6, 月度申报 0 次).
+        拉 size top-N 候选的前几个 exhibit 头部做 _EARNINGS_KEYWORDS 计数,
+        密度最高者胜出. 全部拉取失败 (网络/限速) 返回 None, 调用方退回
+        size 最大 (旧行为, fail-open 与旧路径一致).
+        """
+        ranked = sorted(
+            filings, key=lambda f: int(f.get("size") or 0), reverse=True
+        )[:CONTENT_SNIFF_MAX_CANDIDATES]
+        if self._sec_user_agent:
+            sec_ua = self._sec_user_agent
+        else:
+            from unified_downloader.core.config import get_default_config
+            sec_ua = _resolve_sec_user_agent(get_default_config())
+        headers = {
+            "User-Agent": sec_ua,
+            "Accept": "text/html,application/xhtml+xml,*/*;q=0.8",
+        }
+        best = None
+        best_score = 0
+        for f in ranked:
+            exhibits = [
+                ex for ex in f.get("_exhibits", []) if ex.get("url")
+            ][:CONTENT_SNIFF_MAX_EXHIBITS]
+            score = 0
+            for ex in exhibits:
+                try:
+                    self._rate_limiter.wait("edgar_download")
+                    resp = self._http_client.get(ex["url"], headers=headers)
+                    if resp.status_code != 200:
+                        continue
+                    chunk = resp.content[:CONTENT_SNIFF_MAX_BYTES]
+                    blob = chunk.decode("utf-8", errors="replace").lower()
+                    score += sum(
+                        blob.count(kw) for kw in self._EARNINGS_KEYWORDS
+                    )
+                except Exception as e:
+                    logger.debug(
+                        f"[m_stock] content sniff 拉取失败 {ex.get('url')}: {e}"
+                    )
+            logger.info(
+                f"[m_stock] 6-K 内容嗅探: {f.get('accessionNo')} "
+                f"filed={f.get('filedAt')} size={f.get('size')} "
+                f"财报关键词 {score} 次"
+            )
+            if score > best_score:
+                best = f
+                best_score = score
+        if best is not None:
+            logger.info(
+                f"[m_stock] 6-K 内容嗅探选出 {best.get('accessionNo')} "
+                f"(财报关键词 {best_score} 次)"
+            )
+        return best
 
     def _try_custom_ir_source(
         self,


### PR DESCRIPTION
Fixes #68

## 改动
窗口内 ≥ 50KB 候选多条且 exhibit 元数据打分全 0（描述全是通用 "EXHIBIT 99.1"）时，拉 size top-5 候选的前 2 个 exhibit 头部（各 200KB），按 `_EARNINGS_KEYWORDS` 计数选密度最高者；全部拉取失败退回 size 最大（旧行为）；单候选不嗅探。

## 端到端验证（BABA 2027Q1 真实 SEC 数据）
- 嗅探结果：8/20 真财报 **92 次** vs 月度申报等其余候选 **0 次** -> 正确选中
- 下载落地 461KB（issue #66 所述 8/20 "June Quarter 2026" 真财报）
- morning-brief verifier（#71 修复后）判 **SUCCESS**

## 测试
- 新增 `tests/test_m_stock_content_sniff.py` 5 个用例（密度胜出/拉取失败回退/单候选跳过/非 200 计零/候选数上限）
- 全量 `pytest tests/` **325 passed**