### PR TITLE
fix(m_stock): 财年制静态表补 LULU（财年止 1 月底）

### DIFF
--- a/unified_downloader/adapters/m_stock.py
+++ b/unified_downloader/adapters/m_stock.py
@@ -36,6 +36,7 @@ _FISCAL_YEAR_END_MONTH: Dict[str, int] = {
     "BABA": 3,  # 阿里巴巴 财年止 3 月底
     "NVDA": 1,  # 英伟达 财年止 1 月底 (FY2026 = 2025-02 ~ 2026-01)
     "AAPL": 9,  # 苹果 财年止 9 月底
+    "LULU": 1,  # 露露乐蒙 财年止 1 月底 (周日最近 1/31, 与 morning-brief verifier 表同源)
 }
 
 


### PR DESCRIPTION
配套 morning-brief PR #77（verifier 封面日期证据豁免，LULU 2027Q2 案例）。两处 `_FISCAL_YEAR_END_MONTH` 表为同源约定，本次同步补 LULU。

背景：LULU 10-Q 全文只用日期表述报告期（period ended August 2, 2026），无任何财年标签 → morning-brief verifier 误拦真财报 3 次，完整修复见 winterswang/morning-brief#77（已合并，LULU 实弹 SUCCESS + ima_synced=1）。